### PR TITLE
chore(go): migrate to github.com/pelletier/go-toml.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -112,6 +112,30 @@ linters-settings:
   funlen:
     lines: 100
     statements: 50
+  gomodguard:
+    blocked:
+      modules:
+        - github.com/BurntSushi/toml:
+            recommandations:
+              - github.com/pelletier/go-toml
+  goheader:
+    template: |-
+      Licensed to Elasticsearch B.V. under one or more contributor
+      license agreements. See the NOTICE file distributed with
+      this work for additional information regarding copyright
+      ownership. Elasticsearch B.V. licenses this file to you under
+      the Apache License, Version 2.0 (the "License"); you may
+      not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing,
+      software distributed under the License is distributed on an
+      "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+      KIND, either express or implied.  See the License for the
+      specific language governing permissions and limitations
+      under the License.
 
 issues:
   max-per-linter: 0

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -433,37 +433,6 @@ Contents of probable licence file $GOMODCACHE/github.com/!azure/azure-sdk-for-go
 
 
 --------------------------------------------------------------------------------
-Module  : github.com/BurntSushi/toml
-Version : v0.3.1
-Time    : 2018-08-15T10:47:33Z
-Licence : MIT
-
-Contents of probable licence file $GOMODCACHE/github.com/!burnt!sushi/toml@v0.3.1/COPYING:
-
-The MIT License (MIT)
-
-Copyright (c) 2013 TOML authors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-
---------------------------------------------------------------------------------
 Module  : github.com/Masterminds/sprig/v3
 Version : v3.1.0
 Time    : 2020-04-16T17:44:58Z
@@ -8553,6 +8522,37 @@ Contents of probable licence file $GOMODCACHE/github.com/!azure/go-autorest/trac
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+
+--------------------------------------------------------------------------------
+Module  : github.com/BurntSushi/toml
+Version : v0.3.1
+Time    : 2018-08-15T10:47:33Z
+Licence : MIT
+
+Contents of probable licence file $GOMODCACHE/github.com/!burnt!sushi/toml@v0.3.1/COPYING:
+
+The MIT License (MIT)
+
+Copyright (c) 2013 TOML authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
 
 --------------------------------------------------------------------------------

--- a/docs/dependencies.asciidoc
+++ b/docs/dependencies.asciidoc
@@ -16,7 +16,6 @@ This page lists the third-party dependencies used to build {n}.
 
 | link:https://cloud.google.com/go/storage[$$cloud.google.com/go/storage$$] | v1.12.0 | Apache-2.0
 | link:https://github.com/Azure/azure-sdk-for-go[$$github.com/Azure/azure-sdk-for-go$$] | v48.0.0+incompatible | Apache-2.0
-| link:https://github.com/BurntSushi/toml[$$github.com/BurntSushi/toml$$] | v0.3.1 | MIT
 | link:https://github.com/Masterminds/sprig[$$github.com/Masterminds/sprig/v3$$] | v3.1.0 | MIT
 | link:https://github.com/awnumar/memguard[$$github.com/awnumar/memguard$$] | v0.22.2 | Apache-2.0
 | link:https://github.com/aws/aws-sdk-go[$$github.com/aws/aws-sdk-go$$] | v1.35.20 | Apache-2.0
@@ -94,6 +93,7 @@ This page lists the third-party dependencies used to build {n}.
 | link:https://github.com/Azure/go-autorest[$$github.com/Azure/go-autorest/autorest/to$$] | v0.4.0 | Apache-2.0
 | link:https://github.com/Azure/go-autorest[$$github.com/Azure/go-autorest/logger$$] | v0.2.0 | Apache-2.0
 | link:https://github.com/Azure/go-autorest[$$github.com/Azure/go-autorest/tracing$$] | v0.6.0 | Apache-2.0
+| link:https://github.com/BurntSushi/toml[$$github.com/BurntSushi/toml$$] | v0.3.1 | MIT
 | link:https://github.com/BurntSushi/xgb[$$github.com/BurntSushi/xgb$$] | v0.0.0-20160522181843-27f122750802 | BSD-3-Clause
 | link:https://github.com/Masterminds/goutils[$$github.com/Masterminds/goutils$$] | v1.1.0 | Apache-2.0
 | link:https://github.com/Masterminds/semver[$$github.com/Masterminds/semver/v3$$] | v3.1.0 | MIT

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/Azure/azure-sdk-for-go v48.0.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.11.10 // indirect
 	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect
-	github.com/BurntSushi/toml v0.3.1
 	github.com/Masterminds/sprig/v3 v3.1.0
 	github.com/awnumar/memguard v0.22.2
 	github.com/aws/aws-sdk-go v1.35.20

--- a/pkg/template/engine/funcs_test.go
+++ b/pkg/template/engine/funcs_test.go
@@ -56,7 +56,7 @@ func TestFuncs(t *testing.T) {
 		vars:   `["one", 2, { "name": "helm" }]`,
 	}, {
 		tpl:    `{{ toToml . }}`,
-		expect: "[mast]\n  sail = \"white\"\n",
+		expect: "\n[mast]\n  sail = \"white\"\n",
 		vars:   map[string]map[string]string{"mast": {"sail": "white"}},
 	}, {
 		tpl:    `{{ fromYaml . }}`,

--- a/pkg/template/engine/internal/codec/encoder.go
+++ b/pkg/template/engine/internal/codec/encoder.go
@@ -22,7 +22,7 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/BurntSushi/toml"
+	toml "github.com/pelletier/go-toml"
 	"sigs.k8s.io/yaml"
 )
 

--- a/pkg/template/values/toml/toml.go
+++ b/pkg/template/values/toml/toml.go
@@ -20,7 +20,7 @@ package toml
 import (
 	"fmt"
 
-	"github.com/BurntSushi/toml"
+	toml "github.com/pelletier/go-toml"
 )
 
 // Parser is a TOML parser


### PR DESCRIPTION
# Context

`github.com/BurntSushi/go-toml` is unmaintained.

# Changes

* toml library migrated to `github.com/pelletier/go-toml`
* golangci check validated toml library usage
* golangci enforce valid license header