### PR TITLE
chore(go): update to 1.15.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Download a [release](https://github.com/elastic/harp/releases) or build from sou
 
 ```sh
 $ go version
-go version go1.15.5 darwin/amd64
+go version go1.15.6 darwin/amd64
 ```
 
 > Simple go version manager - <https://github.com/stefanmaric/g>

--- a/build/mage/golang/init.go
+++ b/build/mage/golang/init.go
@@ -29,8 +29,8 @@ import (
 
 // Keep only last 2 versions
 var goVersions = []string{
-	"go1.15.4",
 	"go1.15.5",
+	"go1.15.6",
 }
 
 func init() {


### PR DESCRIPTION
# Context

Update golang to 1.15.6

# Reference(s)

- https://github.com/golang/go/issues?q=milestone%3AGo1.15.6+label%3ACherryPickApproved