### PR TITLE
fix(secret): wrap asn.1 encoding to detect version.

### DIFF
--- a/pkg/bundle/secret/packer.go
+++ b/pkg/bundle/secret/packer.go
@@ -47,6 +47,9 @@ func Pack(value interface{}) ([]byte, error) {
 		Tag:        asn1.TagSequence,
 		Bytes:      append(header, payload...),
 	})
+	if err != nil {
+		return nil, fmt.Errorf("unable to marshal final sequence: %w", err)
+	}
 
 	// No error
 	return body, nil

--- a/pkg/bundle/secret/packer.go
+++ b/pkg/bundle/secret/packer.go
@@ -22,22 +22,63 @@ import (
 	"fmt"
 )
 
+const (
+	formatVersion = int(0x00000001)
+)
+
 // Pack a secret value.
 func Pack(value interface{}) ([]byte, error) {
 	// Encode the payload
-	// JSON is not used to prevents Base64 double encoding.
 	payload, err := asn1.Marshal(value)
 	if err != nil {
 		return nil, fmt.Errorf("unable to pack secret value: %w", err)
 	}
 
-	return payload, nil
+	// Pack header
+	header, err := asn1.Marshal(formatVersion)
+	if err != nil {
+		return nil, fmt.Errorf("unable to marshal header of sequence: %w", err)
+	}
+
+	// Pack body
+	body, err := asn1.Marshal(asn1.RawValue{
+		Class:      asn1.ClassUniversal,
+		IsCompound: true,
+		Tag:        asn1.TagSequence,
+		Bytes:      append(header, payload...),
+	})
+
+	// No error
+	return body, nil
 }
 
 // Unpack a secret value.
 func Unpack(in []byte, out interface{}) error {
+	var raw asn1.RawValue
+
+	_, err := asn1.Unmarshal(in, &raw)
+	if err != nil {
+		return fmt.Errorf("unable to unpack secret header: %w", err)
+	}
+	if raw.Class != asn1.ClassUniversal || raw.Tag != asn1.TagSequence || !raw.IsCompound {
+		return asn1.StructuralError{Msg: fmt.Sprintf(
+			"invalid packed structure object - class [%02x], tag [%02x]",
+			raw.Class, raw.Tag)}
+	}
+
+	var version int
+	rest, err := asn1.Unmarshal(raw.Bytes, &version)
+	if err != nil {
+		return fmt.Errorf("unable to unpack format version: %w", err)
+	}
+
+	// Compare with expected
+	if version != formatVersion {
+		return fmt.Errorf("unexpected packed version, received %d, expected %d", version, formatVersion)
+	}
+
 	// Decode the value
-	if _, err := asn1.Unmarshal(in, out); err != nil {
+	if _, err := asn1.Unmarshal(rest, out); err != nil {
 		return fmt.Errorf("unable to upack secret value: %w", err)
 	}
 

--- a/pkg/bundle/secret/packer_test.go
+++ b/pkg/bundle/secret/packer_test.go
@@ -21,9 +21,10 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	fuzz "github.com/google/gofuzz"
 )
 
-func Test_Pack_Unpack(t *testing.T) {
+func Test_Pack_Pack_Unpack(t *testing.T) {
 	testCases := []struct {
 		desc    string
 		in      interface{}
@@ -75,5 +76,23 @@ func Test_Pack_Unpack(t *testing.T) {
 				t.Errorf("%q. Secret.PackUnpack():\n-got/+want\ndiff %s", tC.desc, diff)
 			}
 		})
+	}
+}
+
+func Test_UnPack_Fuzz(t *testing.T) {
+	// Making sure the descrption never panics
+	for i := 0; i < 100000; i++ {
+		f := fuzz.New()
+
+		var (
+			in  []byte
+			out struct{}
+		)
+
+		// Fuzz input
+		f.Fuzz(&in)
+
+		// Execute
+		Unpack(in, &out)
 	}
 }

--- a/pkg/bundle/vault/internal/operation/exporter.go
+++ b/pkg/bundle/vault/internal/operation/exporter.go
@@ -131,7 +131,7 @@ func (op *exporter) Run(ctx context.Context) error {
 					// Pack secret value
 					s, errPack := op.packSecret(k, v)
 					if errPack != nil {
-						return fmt.Errorf("unable to pack secret value for path '%s' with key '%s' : %w", secPath, k)
+						return fmt.Errorf("unable to pack secret value for path '%s' with key '%s' : %w", secPath, k, err)
 					}
 
 					// Add secret to package

--- a/pkg/bundle/vault/internal/operation/exporter.go
+++ b/pkg/bundle/vault/internal/operation/exporter.go
@@ -131,7 +131,7 @@ func (op *exporter) Run(ctx context.Context) error {
 					// Pack secret value
 					s, errPack := op.packSecret(k, v)
 					if errPack != nil {
-						return errPack
+						return fmt.Errorf("unable to pack secret value for path '%s' with key '%s' : %w", secPath, k)
 					}
 
 					// Add secret to package

--- a/pkg/bundle/vault/internal/operation/importer.go
+++ b/pkg/bundle/vault/internal/operation/importer.go
@@ -104,7 +104,7 @@ func (op *importer) Run(ctx context.Context) error {
 					// Unpack secret to original value
 					var value interface{}
 					if err := secret.Unpack(s.Value, &value); err != nil {
-						return fmt.Errorf("unable to unpack secret value for path '%s': %w", secretPackage.Name, err)
+						return fmt.Errorf("unable to unpack secret value for path '%s' with key '%s': %w", secretPackage.Name, s.Key, err)
 					}
 
 					// Assign to map for vault storage


### PR DESCRIPTION
# Context

Secret values are packed using ASN.1 (previously msgpack), this is stricter than msgpack. I want to enforce by design that secret KV must be sort of `map[string]string` in order to prevent subtree inside a secret value.
If a secret value is an object, it must be encoded as a string (using JSON encoding for example) before inserting it as secret. 

A cleaner error message is also produced in order to help the user to diagnose which secret path is responsible for the error raise.