### PR TITLE
fix(pack): error wrapping was using wrong error object.

### DIFF
--- a/pkg/bundle/vault/internal/operation/exporter.go
+++ b/pkg/bundle/vault/internal/operation/exporter.go
@@ -131,7 +131,7 @@ func (op *exporter) Run(ctx context.Context) error {
 					// Pack secret value
 					s, errPack := op.packSecret(k, v)
 					if errPack != nil {
-						return fmt.Errorf("unable to pack secret value for path '%s' with key '%s' : %w", secPath, k, err)
+						return fmt.Errorf("unable to pack secret value for path '%s' with key '%s' : %w", secPath, k, errPack)
 					}
 
 					// Add secret to package


### PR DESCRIPTION
# Context

Error wrapping was using wrong error instance.