### PR TITLE
feat(harp-server): Vault transit backend API for transformers.

### DIFF
--- a/cmd/harp-server/go.mod
+++ b/cmd/harp-server/go.mod
@@ -9,12 +9,13 @@ replace github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.1-0.20181028
 
 require (
 	github.com/common-nighthawk/go-figure v0.0.0-20200609044655-c4b36f998cf2
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dchest/uniuri v0.0.0-20200228104902-7aecb25e1fe5
 	github.com/elastic/harp v0.0.0-00010101000000-000000000000
 	github.com/fatih/color v1.10.0
 	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/google/wire v0.4.0
-	github.com/gorilla/schema v1.2.0
+	github.com/gorilla/schema v1.2.0 // indirect
 	github.com/gosimple/slug v1.9.0
 	github.com/json-iterator/go v1.1.10 // indirect
 	github.com/magefile/mage v1.10.0

--- a/cmd/harp-server/go.mod
+++ b/cmd/harp-server/go.mod
@@ -14,8 +14,9 @@ require (
 	github.com/fatih/color v1.10.0
 	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/google/wire v0.4.0
+	github.com/gorilla/schema v1.2.0
 	github.com/gosimple/slug v1.9.0
-	github.com/json-iterator/go v1.1.10
+	github.com/json-iterator/go v1.1.10 // indirect
 	github.com/magefile/mage v1.10.0
 	github.com/oklog/run v1.1.0
 	github.com/spf13/cobra v1.1.1

--- a/cmd/harp-server/go.sum
+++ b/cmd/harp-server/go.sum
@@ -228,6 +228,8 @@ github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gorilla/schema v1.2.0 h1:YufUaxZYCKGFuAq3c96BOhjgd5nmXiOY9NGzF247Tsc=
+github.com/gorilla/schema v1.2.0/go.mod h1:kgLaKoK1FELgZqMAVxx/5cbj0kT+57qxUrAlIO2eleU=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gosimple/slug v1.9.0 h1:r5vDcYrFz9BmfIAMC829un9hq7hKM4cHUrsv36LbEqs=
 github.com/gosimple/slug v1.9.0/go.mod h1:AMZ+sOVe65uByN3kgEyf9WEBKBCSS+dJjMX9x4vDJbg=

--- a/cmd/harp-server/internal/cmd/http.go
+++ b/cmd/harp-server/internal/cmd/http.go
@@ -139,3 +139,33 @@ func overrideBackendConfig(cfg *config.Configuration, backends []string) error {
 
 	return nil
 }
+
+func overrideTransformerConfig(cfg *config.Configuration, transformers []string) error {
+	// Parse backend mapping declaration
+	for _, decl := range transformers {
+		parts := strings.SplitN(decl, ":", 2)
+
+		// Mapping must have 2 parts
+		if len(parts) != 2 {
+			return fmt.Errorf("unable to parse transformer declaration, invalid part count")
+		}
+
+		keyName := parts[0]
+		keyRaw := parts[1]
+
+		log.Bg().Debug("Transformer override", zap.String("keyName", keyName))
+
+		// Initialize transformer list
+		if cfg.Transformers == nil {
+			cfg.Transformers = []config.Transformer{}
+		}
+
+		// Add to backend
+		cfg.Transformers = append(cfg.Transformers, config.Transformer{
+			Name: keyName,
+			Key:  keyRaw,
+		})
+	}
+
+	return nil
+}

--- a/cmd/harp-server/internal/config/config.go
+++ b/cmd/harp-server/internal/config/config.go
@@ -63,6 +63,8 @@ type Configuration struct {
 
 	Backends []Backend `toml:"Backends" default:"" comment:"###############################\n Backends \n##############################"`
 
+	Transformers []Transformer `toml:"Transformers" default:"" comment:"###############################\n Tranformers \n##############################"`
+
 	Keyring []string `toml:"Keyring" default:"" comment:"###############################\n Container Keyring \n##############################"`
 }
 
@@ -70,4 +72,10 @@ type Configuration struct {
 type Backend struct {
 	NS  string `toml:"ns" default:"" comment:"Backend mount namespace"`
 	URL string `toml:"url" default:"" comment:"Backend settings url"`
+}
+
+// Transformer represents transformer mapping settings
+type Transformer struct {
+	Name string `toml:"name" default:"" comment:"Transformer key name"`
+	Key  string `toml:"key" default:"" comment:"Transformer key"`
 }

--- a/cmd/harp-server/internal/dispatchers/vault/routes/api.go
+++ b/cmd/harp-server/internal/dispatchers/vault/routes/api.go
@@ -1,0 +1,21 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package routes
+
+// KV is an alias to map for readability.
+type KV map[string]interface{}

--- a/cmd/harp-server/internal/dispatchers/vault/routes/helpers.go
+++ b/cmd/harp-server/internal/dispatchers/vault/routes/helpers.go
@@ -18,9 +18,14 @@
 package routes
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
 	"net/http"
+	"strings"
 
-	jsoniter "github.com/json-iterator/go"
+	"github.com/gorilla/schema"
 
 	"github.com/elastic/harp/pkg/sdk/log"
 )
@@ -45,8 +50,6 @@ type status struct {
 
 // with serializes the data with matching requested encoding
 func with(w http.ResponseWriter, r *http.Request, code int, data interface{}) {
-	json := jsoniter.ConfigCompatibleWithStandardLibrary
-
 	// Marshal response as json
 	js, err := json.Marshal(data)
 	if err != nil {
@@ -93,4 +96,97 @@ func withError(w http.ResponseWriter, r *http.Request, err interface{}) {
 			Message: "Unable to process this request",
 		})
 	}
+}
+
+// gorilla/schema decoder is a shared object, as it caches information about structs
+var decoder = schema.NewDecoder()
+
+// Parse takes the input body from the passed request and tries to unmarshal it into data
+func parseRequest(w http.ResponseWriter, r *http.Request, data interface{}) error {
+	// Get the contentType for comparisons
+	contentType := r.Header.Get("Content-Type")
+
+	// Determine the passed ContentType
+	if strings.Contains(contentType, "application/json") {
+		return decodeJSONBody(w, r, data)
+	} else if contentType == "" ||
+		strings.Contains(contentType, "application/x-www-form-urlencoded") ||
+		strings.Contains(contentType, "multipart/form-data") {
+		// net/http should be capable of parsing the form data
+		err := r.ParseForm()
+		if err != nil {
+			return err
+		}
+
+		// Unmarshal them into the passed interface
+		err = decoder.Decode(data, r.PostForm)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	return &malformedRequest{status: http.StatusUnsupportedMediaType, msg: "Content-Type header value is not supported"}
+}
+
+type malformedRequest struct {
+	status int
+	msg    string
+}
+
+func (mr *malformedRequest) Error() string {
+	return mr.msg
+}
+
+func decodeJSONBody(w http.ResponseWriter, r *http.Request, dst interface{}) error {
+	// Limit body size to 1Mb
+	r.Body = http.MaxBytesReader(w, r.Body, 1048576)
+
+	// Disallow unknown fields deserialization
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+
+	err := dec.Decode(&dst)
+	if err != nil {
+		var syntaxError *json.SyntaxError
+		var unmarshalTypeError *json.UnmarshalTypeError
+
+		switch {
+		case errors.As(err, &syntaxError):
+			msg := fmt.Sprintf("Request body contains badly-formed JSON (at position %d)", syntaxError.Offset)
+			return &malformedRequest{status: http.StatusBadRequest, msg: msg}
+
+		case errors.Is(err, io.ErrUnexpectedEOF):
+			msg := "Request body contains badly-formed JSON"
+			return &malformedRequest{status: http.StatusBadRequest, msg: msg}
+
+		case errors.As(err, &unmarshalTypeError):
+			msg := fmt.Sprintf("Request body contains an invalid value for the %q field (at position %d)", unmarshalTypeError.Field, unmarshalTypeError.Offset)
+			return &malformedRequest{status: http.StatusBadRequest, msg: msg}
+
+		case strings.HasPrefix(err.Error(), "json: unknown field "):
+			fieldName := strings.TrimPrefix(err.Error(), "json: unknown field ")
+			msg := fmt.Sprintf("Request body contains unknown field %s", fieldName)
+			return &malformedRequest{status: http.StatusBadRequest, msg: msg}
+
+		case errors.Is(err, io.EOF):
+			msg := "Request body must not be empty"
+			return &malformedRequest{status: http.StatusBadRequest, msg: msg}
+
+		case err.Error() == "http: request body too large":
+			msg := "Request body must not be larger than 1MB"
+			return &malformedRequest{status: http.StatusRequestEntityTooLarge, msg: msg}
+
+		default:
+			return err
+		}
+	}
+
+	if dec.More() {
+		msg := "Request body must only contain a single JSON object"
+		return &malformedRequest{status: http.StatusBadRequest, msg: msg}
+	}
+
+	return nil
 }

--- a/cmd/harp-server/internal/dispatchers/vault/routes/helpers.go
+++ b/cmd/harp-server/internal/dispatchers/vault/routes/helpers.go
@@ -25,8 +25,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/gorilla/schema"
-
 	"github.com/elastic/harp/pkg/sdk/log"
 )
 
@@ -96,38 +94,6 @@ func withError(w http.ResponseWriter, r *http.Request, err interface{}) {
 			Message: "Unable to process this request",
 		})
 	}
-}
-
-// gorilla/schema decoder is a shared object, as it caches information about structs
-var decoder = schema.NewDecoder()
-
-// Parse takes the input body from the passed request and tries to unmarshal it into data
-func parseRequest(w http.ResponseWriter, r *http.Request, data interface{}) error {
-	// Get the contentType for comparisons
-	contentType := r.Header.Get("Content-Type")
-
-	// Determine the passed ContentType
-	if strings.Contains(contentType, "application/json") {
-		return decodeJSONBody(w, r, data)
-	} else if contentType == "" ||
-		strings.Contains(contentType, "application/x-www-form-urlencoded") ||
-		strings.Contains(contentType, "multipart/form-data") {
-		// net/http should be capable of parsing the form data
-		err := r.ParseForm()
-		if err != nil {
-			return err
-		}
-
-		// Unmarshal them into the passed interface
-		err = decoder.Decode(data, r.PostForm)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	}
-
-	return &malformedRequest{status: http.StatusUnsupportedMediaType, msg: "Content-Type header value is not supported"}
 }
 
 type malformedRequest struct {

--- a/cmd/harp-server/internal/dispatchers/vault/routes/root.go
+++ b/cmd/harp-server/internal/dispatchers/vault/routes/root.go
@@ -1,0 +1,83 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package routes
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/dchest/uniuri"
+	"github.com/go-chi/chi"
+
+	"github.com/elastic/harp/build/version"
+)
+
+// RootHandler initializes Vault KV API handler for given bundle
+func RootHandler(r chi.Router) {
+	// Initialize controler
+	ctrl := &vaultRootHandler{}
+
+	// Map routes
+	r.Get("/v1/sys/seal-status", ctrl.sealStatus())
+	r.Get("/v1/sys/leader", ctrl.leaderStatus())
+	r.Put("/v1/auth/token/renew-self", ctrl.selfRenew())
+}
+
+type vaultRootHandler struct{}
+
+func (h *vaultRootHandler) sealStatus() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		with(w, r, http.StatusOK, &KV{
+			"type":         "shamir",
+			"initialized":  true,
+			"sealed":       false,
+			"t":            1,
+			"n":            1,
+			"progress":     0,
+			"version":      version.Version,
+			"cluster_name": "harp-container-server",
+			"cluster_id":   "763d1163-18f9-46d8-b1ca-2d327c0cc57f",
+			"nonce":        "",
+		})
+	}
+}
+
+func (h *vaultRootHandler) leaderStatus() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		with(w, r, http.StatusOK, &KV{
+			"ha_enabled": false,
+			"is_self":    true,
+		})
+	}
+}
+
+func (h *vaultRootHandler) selfRenew() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		with(w, r, http.StatusOK, &KV{
+			"auth": &KV{
+				"client_token": fmt.Sprintf("harp.%s", uniuri.NewLen(12)),
+				"policies":     []string{"harp", "read-only"},
+				"metadata": &KV{
+					"user": "harp",
+				},
+				"lease_duration": 3600,
+				"renewable":      true,
+			},
+		})
+	}
+}

--- a/cmd/harp-server/internal/dispatchers/vault/routes/transit.go
+++ b/cmd/harp-server/internal/dispatchers/vault/routes/transit.go
@@ -1,0 +1,123 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package routes
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+
+	"github.com/go-chi/chi"
+	"github.com/gosimple/slug"
+
+	"github.com/elastic/harp/pkg/sdk/value"
+)
+
+// TransitHandler initializes Vault Transit API handler for given transformer
+func TransitHandler(r chi.Router, keyName string, tr value.Transformer) {
+	// Initialize controler
+	ctrl := &vaultTransitHandler{
+		tr: tr,
+	}
+
+	// Map routes
+	r.Post(fmt.Sprintf("/v1/transit/encrypt/%s", slug.Make(keyName)), ctrl.encryptData())
+	r.Put(fmt.Sprintf("/v1/transit/encrypt/%s", slug.Make(keyName)), ctrl.encryptData())
+	r.Post(fmt.Sprintf("/v1/transit/decrypt/%s", slug.Make(keyName)), ctrl.decryptData())
+	r.Put(fmt.Sprintf("/v1/transit/decrypt/%s", slug.Make(keyName)), ctrl.decryptData())
+}
+
+type vaultTransitHandler struct {
+	tr value.Transformer
+}
+
+func (h *vaultTransitHandler) encryptData() http.HandlerFunc {
+	type request struct {
+		PlainText  string    `json:"plaintext,omitempty"`
+		Context    string    `json:"context,omitempty"`
+		Nonce      string    `json:"nonce,omitempty"`
+		BatchInput []request `json:"batch_input,omitempty"`
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req request
+		if err := parseRequest(w, r, &req); err != nil {
+			http.Error(w, "request is invalid", http.StatusBadRequest)
+			return
+		}
+
+		// Check plaintext encoding
+		rawPlainText, err := base64.StdEncoding.DecodeString(req.PlainText)
+		if err != nil {
+			http.Error(w, "plaintext must be a valid base64 encoded value", http.StatusBadRequest)
+			return
+		}
+
+		// Encrypt plaintext with transformer
+		cipherRaw, err := h.tr.To(r.Context(), rawPlainText)
+		if err != nil {
+			http.Error(w, "unable to encrypt plaintext", http.StatusInternalServerError)
+			return
+		}
+
+		// Return response
+		with(w, r, http.StatusOK, &KV{
+			"data": &KV{
+				"ciphertext": fmt.Sprintf("vault:v1:%s", base64.StdEncoding.EncodeToString(cipherRaw)),
+			},
+		})
+	}
+}
+
+func (h *vaultTransitHandler) decryptData() http.HandlerFunc {
+	type request struct {
+		CipherText string    `json:"ciphertext,omitempty"`
+		Context    string    `json:"context,omitempty"`
+		Nonce      string    `json:"nonce,omitempty"`
+		BatchInput []request `json:"batch_input,omitempty"`
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req request
+		if err := parseRequest(w, r, &req); err != nil {
+			http.Error(w, "request is invalid", http.StatusBadRequest)
+			return
+		}
+
+		// Check plaintext encoding
+		rawCipherText, err := base64.StdEncoding.DecodeString(req.CipherText)
+		if err != nil {
+			http.Error(w, "ciphertext must be a valid base64 encoded value", http.StatusBadRequest)
+			return
+		}
+
+		// Encrypt plaintext with transformer
+		cipherRaw, err := h.tr.To(r.Context(), rawCipherText)
+		if err != nil {
+			http.Error(w, "unable to decrypt ciphertext", http.StatusInternalServerError)
+			return
+		}
+
+		// Return response
+		with(w, r, http.StatusOK, &KV{
+			"data": &KV{
+				"plaintext": base64.StdEncoding.EncodeToString(cipherRaw),
+			},
+		})
+	}
+}

--- a/cmd/harp-server/internal/dispatchers/vault/routes/transit.go
+++ b/cmd/harp-server/internal/dispatchers/vault/routes/transit.go
@@ -49,10 +49,7 @@ type vaultTransitHandler struct {
 
 func (h *vaultTransitHandler) encryptData() http.HandlerFunc {
 	type request struct {
-		PlainText  string    `json:"plaintext,omitempty"`
-		Context    string    `json:"context,omitempty"`
-		Nonce      string    `json:"nonce,omitempty"`
-		BatchInput []request `json:"batch_input,omitempty"`
+		PlainText string `json:"plaintext,omitempty"`
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -72,7 +69,7 @@ func (h *vaultTransitHandler) encryptData() http.HandlerFunc {
 		// Encrypt plaintext with transformer
 		cipherRaw, err := h.tr.To(r.Context(), rawPlainText)
 		if err != nil {
-			http.Error(w, "unable to encrypt plaintext", http.StatusInternalServerError)
+			http.Error(w, "unable to encrypt plaintext", http.StatusBadRequest)
 			return
 		}
 
@@ -87,10 +84,7 @@ func (h *vaultTransitHandler) encryptData() http.HandlerFunc {
 
 func (h *vaultTransitHandler) decryptData() http.HandlerFunc {
 	type request struct {
-		CipherText string    `json:"ciphertext,omitempty"`
-		Context    string    `json:"context,omitempty"`
-		Nonce      string    `json:"nonce,omitempty"`
-		BatchInput []request `json:"batch_input,omitempty"`
+		CipherText string `json:"ciphertext,omitempty"`
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -113,7 +107,7 @@ func (h *vaultTransitHandler) decryptData() http.HandlerFunc {
 		// Encrypt plaintext with transformer
 		cipherRaw, err := h.tr.From(r.Context(), rawCipherText)
 		if err != nil {
-			http.Error(w, "unable to decrypt ciphertext", http.StatusInternalServerError)
+			http.Error(w, "unable to decrypt ciphertext", http.StatusBadRequest)
 			return
 		}
 


### PR DESCRIPTION
# Context

Expose transformers using a limited Vault Transit HTTP API.

* `[POST/PUT] /v1/transit/encrypt/:name`
* `[POST/PUT] /v1/transit/decrypt/:name`

Harp supports additional encryption algorithm not supported by Vault at the moment :

* `aes-256` match `aes256-gcm96` in Vault
* `fernet` and `secretbox (XSalsa20+Poly1305)` are not supported
 
# Sample

<img width="780" alt="Capture d’écran 2020-12-16 à 09 41 24" src="https://user-images.githubusercontent.com/3110/102325889-00684b00-3f84-11eb-844d-9f66374dd7d7.png">
