### PR TITLE
Chore go update (1.15.7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Download a [release](https://github.com/elastic/harp/releases) or build from sou
 
 ```sh
 $ go version
-go version go1.15.6 darwin/amd64
+go version go1.15.7 darwin/amd64
 ```
 
 > Simple go version manager - <https://github.com/stefanmaric/g>

--- a/build/mage/docker/build.go
+++ b/build/mage/docker/build.go
@@ -20,12 +20,12 @@ package docker
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 	"time"
 
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/elastic/harp/build/artifact"
 	"github.com/elastic/harp/build/mage/git"
@@ -126,7 +126,7 @@ func Build(cmd *artifact.Command) func() error {
 		}
 
 		// Prepare command
-		//nolint:gosec // expected behavior
+		// expected behavior
 		c := exec.Command("docker", "build",
 			"-t", fmt.Sprintf("elastic/%s", cmd.Kebab()),
 			"-f", "-",

--- a/build/mage/docker/release.go
+++ b/build/mage/docker/release.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 	"text/template"
 	"time"
@@ -29,6 +28,7 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/elastic/harp/build/artifact"
 	"github.com/elastic/harp/build/mage/git"
@@ -136,7 +136,7 @@ func Release(cmd *artifact.Command) func() error {
 		}
 
 		// Prepare command
-		//nolint:gosec // expected behavior
+		// expected behavior
 		c := exec.Command("docker", "build",
 			"-t", fmt.Sprintf("elastic/%s:artifacts-%s", cmd.Kebab(), relVer.String()),
 			"-f", "-",

--- a/build/mage/docker/tools.go
+++ b/build/mage/docker/tools.go
@@ -20,12 +20,12 @@ package docker
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 	"time"
 
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/elastic/harp/build/mage/git"
 )
@@ -120,7 +120,7 @@ func Tools() error {
 	}
 
 	// Prepare command
-	//nolint:gosec // expected behavior
+	// expected behavior
 	c := exec.Command("docker", "build",
 		"-t", "elastic/harp-tools",
 		"-f", "-",

--- a/build/mage/golang/init.go
+++ b/build/mage/golang/init.go
@@ -29,8 +29,8 @@ import (
 
 // Keep only last 2 versions
 var goVersions = []string{
-	"go1.15.5",
 	"go1.15.6",
+	"go1.15.7",
 }
 
 func init() {

--- a/build/mage/golang/source.go
+++ b/build/mage/golang/source.go
@@ -21,8 +21,9 @@ import (
 	"bufio"
 	"bytes"
 	"os"
-	"os/exec"
 	"strings"
+
+	exec "golang.org/x/sys/execabs"
 )
 
 // PathSeparatorString models the os.PathSeparator as a string.

--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	go.uber.org/zap v1.16.0
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
+	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4
 	golang.org/x/term v0.0.0-20201117132131-f5c789dd3221
 	google.golang.org/grpc v1.34.1
 	google.golang.org/protobuf v1.25.0

--- a/go.sum
+++ b/go.sum
@@ -639,6 +639,8 @@ golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d h1:MiWWjyhUzZ+jvhZvloX6ZrUsdEghn8a64Upd8EMHglE=
 golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 h1:myAQVi0cGEoqQVR5POX+8RR2mrocKqNN1hmeMqhX27k=
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/sdk/cmdutil/bug.go
+++ b/pkg/sdk/cmdutil/bug.go
@@ -23,16 +23,17 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/elastic/harp/build/version"
 )
 
 // BugReport generates a bug report body
-// nolint:godox // Bug not allow in documentation
+//nolint:godox // Bug not allow in documentation
 func BugReport() string {
 	var buf bytes.Buffer
 	buf.WriteString(bugHeader)
@@ -176,7 +177,7 @@ func printGlibcVersion(w io.Writer) {
 	if m == nil {
 		return
 	}
-	cmd = exec.Command(m[1]) // nolint:gosec // controlled input
+	cmd = exec.Command(m[1]) // controlled input
 	out, err = cmd.Output()
 	if err != nil {
 		return

--- a/pkg/sdk/cmdutil/plugin.go
+++ b/pkg/sdk/cmdutil/plugin.go
@@ -20,10 +20,11 @@ package cmdutil
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"runtime"
 	"strings"
 	"syscall"
+
+	exec "golang.org/x/sys/execabs"
 )
 
 // PluginHandler is capable of parsing command line arguments


### PR DESCRIPTION
# Context

- Update go toolchain constraint to [1.15.6, 1.15.7]
- Migrate `os/exec` package usage to `golang.org/x/sys/execabs`

# Reference(s)

- https://blog.golang.org/path-security
- https://groups.google.com/g/golang-announce/c/mperVMGa98w