### PR TITLE
fix(go): use NumCpu in place of GOMAXPROCS.

### DIFF
--- a/cmd/harp/internal/cmd/from_vault.go
+++ b/cmd/harp/internal/cmd/from_vault.go
@@ -30,11 +30,12 @@ import (
 
 var fromVaultCmd = func() *cobra.Command {
 	var (
-		pathsFrom    string
-		secretPaths  []string
-		outputPath   string
-		namespace    string
-		withMetadata bool
+		pathsFrom      string
+		secretPaths    []string
+		outputPath     string
+		namespace      string
+		withMetadata   bool
+		maxWorkerCount int64
 	)
 
 	cmd := &cobra.Command{
@@ -63,6 +64,7 @@ var fromVaultCmd = func() *cobra.Command {
 				SecretPaths:    secretPaths,
 				VaultNamespace: namespace,
 				WithMetadata:   withMetadata,
+				MaxWorkerCount: maxWorkerCount,
 			}
 
 			// Run the task
@@ -78,6 +80,7 @@ var fromVaultCmd = func() *cobra.Command {
 	cmd.Flags().StringVar(&outputPath, "out", "", "Container output ('-' for stdout or filename)")
 	cmd.Flags().StringVar(&namespace, "namespace", "", "Vault namespace")
 	cmd.Flags().BoolVar(&withMetadata, "with-metadata", true, "Pull bundle metadata from Vault")
+	cmd.Flags().Int64Var(&maxWorkerCount, "worker-count", 4, "Active worker count limit")
 
 	return cmd
 }

--- a/cmd/harp/internal/cmd/to_vault.go
+++ b/cmd/harp/internal/cmd/to_vault.go
@@ -30,10 +30,11 @@ import (
 
 var toVaultCmd = func() *cobra.Command {
 	var (
-		inputPath     string
-		backendPrefix string
-		namespace     string
-		withMetadata  bool
+		inputPath      string
+		backendPrefix  string
+		namespace      string
+		withMetadata   bool
+		maxWorkerCount int64
 	)
 
 	cmd := &cobra.Command{
@@ -50,6 +51,7 @@ var toVaultCmd = func() *cobra.Command {
 				BackendPrefix:   backendPrefix,
 				PushMetadata:    withMetadata,
 				VaultNamespace:  namespace,
+				MaxWorkerCount:  maxWorkerCount,
 			}
 
 			// Run the task
@@ -64,6 +66,7 @@ var toVaultCmd = func() *cobra.Command {
 	cmd.Flags().StringVar(&backendPrefix, "prefix", "", "Vault backend prefix")
 	cmd.Flags().StringVar(&namespace, "namespace", "", "Vault namespace")
 	cmd.Flags().BoolVar(&withMetadata, "with-metadata", false, "Push container metadata")
+	cmd.Flags().Int64Var(&maxWorkerCount, "worker-count", 4, "Active worker count limit")
 
 	return cmd
 }

--- a/pkg/bundle/vault/internal/operation/exporter.go
+++ b/pkg/bundle/vault/internal/operation/exporter.go
@@ -50,7 +50,7 @@ func Exporter(service kv.Service, backendPath string, output chan *bundlev1.Pack
 // -----------------------------------------------------------------------------
 
 // Use as many proc as we have logical CPUs
-var maxReaderWorker = runtime.GOMAXPROCS(0)
+var maxReaderWorker = runtime.NumCPU() + 1
 
 // -----------------------------------------------------------------------------
 

--- a/pkg/bundle/vault/internal/operation/exporter.go
+++ b/pkg/bundle/vault/internal/operation/exporter.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"path"
-	"runtime"
 	"strings"
 
 	"github.com/imdario/mergo"
@@ -38,27 +37,24 @@ import (
 )
 
 // Exporter initialize a secret exporter operation
-func Exporter(service kv.Service, backendPath string, output chan *bundlev1.Package, withMetadata bool) Operation {
+func Exporter(service kv.Service, backendPath string, output chan *bundlev1.Package, withMetadata bool, maxWorkerCount int64) Operation {
 	return &exporter{
-		service:      service,
-		path:         backendPath,
-		withMetadata: withMetadata,
-		output:       output,
+		service:        service,
+		path:           backendPath,
+		withMetadata:   withMetadata,
+		output:         output,
+		maxWorkerCount: maxWorkerCount,
 	}
 }
 
 // -----------------------------------------------------------------------------
 
-// Use as many proc as we have logical CPUs
-var maxReaderWorker = runtime.NumCPU() + 1
-
-// -----------------------------------------------------------------------------
-
 type exporter struct {
-	service      kv.Service
-	path         string
-	withMetadata bool
-	output       chan *bundlev1.Package
+	service        kv.Service
+	path           string
+	withMetadata   bool
+	output         chan *bundlev1.Package
+	maxWorkerCount int64
 }
 
 // Run the implemented operation
@@ -70,12 +66,17 @@ func (op *exporter) Run(ctx context.Context) error {
 	// Prepare channels
 	pathChan := make(chan string)
 
+	// Validate worker count
+	if op.maxWorkerCount < 1 {
+		op.maxWorkerCount = 1
+	}
+
 	// Consumers ---------------------------------------------------------------
 
 	// Secret reader
 	g.Go(func() error {
 		// Initialize a semaphore with maxReaderWorker tokens
-		sem := semaphore.NewWeighted(int64(maxReaderWorker))
+		sem := semaphore.NewWeighted(op.maxWorkerCount)
 
 		// Reader errGroup
 		gReader, gReaderCtx := errgroup.WithContext(gctx)

--- a/pkg/bundle/vault/options.go
+++ b/pkg/bundle/vault/options.go
@@ -25,6 +25,7 @@ import (
 type options struct {
 	prefix       string
 	withMetadata bool
+	workerCount  int64
 	exclusions   []*regexp.Regexp
 	includes     []*regexp.Regexp
 }
@@ -79,6 +80,15 @@ func WithPrefix(value string) Option {
 func WithMetadata(value bool) Option {
 	return func(opts *options) error {
 		opts.withMetadata = value
+		// No error
+		return nil
+	}
+}
+
+// WithMaxWorkerCount sets the maximum count of active operation worker count.
+func WithMaxWorkerCount(value int64) Option {
+	return func(opts *options) error {
+		opts.workerCount = value
 		// No error
 		return nil
 	}

--- a/pkg/bundle/vault/pull.go
+++ b/pkg/bundle/vault/pull.go
@@ -47,6 +47,7 @@ func Pull(ctx context.Context, client *api.Client, paths []string, opts ...Optio
 		defaultPathInclusions = []*regexp.Regexp{}
 		defaultPathExclusions = []*regexp.Regexp{}
 		defaultWithMetadata   = false
+		defaultWorkerCount    = int64(4)
 	)
 
 	// Create default option instance
@@ -55,6 +56,7 @@ func Pull(ctx context.Context, client *api.Client, paths []string, opts ...Optio
 		exclusions:   defaultPathExclusions,
 		includes:     defaultPathInclusions,
 		withMetadata: defaultWithMetadata,
+		workerCount:  defaultWorkerCount,
 	}
 
 	// Apply option functions
@@ -126,7 +128,7 @@ func runPull(ctx context.Context, client *api.Client, paths []string, opts *opti
 				}
 
 				// Create an exporter
-				op := operation.Exporter(service, vpath.SanitizePath(p), packageChan, opts.withMetadata)
+				op := operation.Exporter(service, vpath.SanitizePath(p), packageChan, opts.withMetadata, opts.workerCount)
 
 				// Run the job
 				if err := op.Run(gReaderctx); err != nil {

--- a/pkg/bundle/vault/push.go
+++ b/pkg/bundle/vault/push.go
@@ -44,6 +44,7 @@ func Push(ctx context.Context, b *bundlev1.Bundle, client *api.Client, opts ...O
 		defaultPathInclusions = []*regexp.Regexp{}
 		defaultPathExclusions = []*regexp.Regexp{}
 		defaultWithMetadata   = false
+		defaultWorkerCount    = int64(4)
 	)
 
 	// Create default option instance
@@ -52,6 +53,7 @@ func Push(ctx context.Context, b *bundlev1.Bundle, client *api.Client, opts ...O
 		exclusions:   defaultPathExclusions,
 		includes:     defaultPathInclusions,
 		withMetadata: defaultWithMetadata,
+		workerCount:  defaultWorkerCount,
 	}
 
 	// Apply option functions
@@ -87,7 +89,7 @@ func runPush(ctx context.Context, b *bundlev1.Bundle, client *api.Client, opts *
 	}
 
 	// Initialize operation
-	op := operation.Importer(client, b, opts.prefix, opts.withMetadata)
+	op := operation.Importer(client, b, opts.prefix, opts.withMetadata, opts.workerCount)
 
 	// Run the vault operation
 	if err := op.Run(ctx); err != nil {

--- a/pkg/tasks/from/vault.go
+++ b/pkg/tasks/from/vault.go
@@ -34,6 +34,7 @@ type VaultTask struct {
 	SecretPaths    []string
 	VaultNamespace string
 	WithMetadata   bool
+	MaxWorkerCount int64
 }
 
 // Run the task.
@@ -52,6 +53,7 @@ func (t *VaultTask) Run(ctx context.Context) error {
 	// Call exporter
 	b, err := bundlevault.Pull(ctx, client, t.SecretPaths,
 		bundlevault.WithMetadata(t.WithMetadata),
+		bundlevault.WithMaxWorkerCount(t.MaxWorkerCount),
 	)
 	if err != nil {
 		return fmt.Errorf("error occurs during vault export: %w", err)

--- a/pkg/tasks/to/vault.go
+++ b/pkg/tasks/to/vault.go
@@ -34,6 +34,7 @@ type VaultTask struct {
 	BackendPrefix   string
 	PushMetadata    bool
 	VaultNamespace  string
+	MaxWorkerCount  int64
 }
 
 // Run the task.
@@ -65,6 +66,7 @@ func (t *VaultTask) Run(ctx context.Context) error {
 	if err := bundlevault.Push(ctx, b, client,
 		bundlevault.WithPrefix(t.BackendPrefix),
 		bundlevault.WithMetadata(t.PushMetadata),
+		bundlevault.WithMaxWorkerCount(t.MaxWorkerCount),
 	); err != nil {
 		return fmt.Errorf("error occurs during vault export (prefix: '%s'): %w", t.BackendPrefix, err)
 	}


### PR DESCRIPTION
# Context

Change `GOMAXPROCS` to `NumCpu +1` to prevent no CPU allocation due to detection problem in a docker container.