### PR TITLE
fix(vault): don't hide vault error.

### DIFF
--- a/pkg/bundle/vault/internal/operation/importer.go
+++ b/pkg/bundle/vault/internal/operation/importer.go
@@ -89,6 +89,11 @@ func (op *importer) Run(ctx context.Context) error {
 			// Assign local reference
 			secretPackage := secretPackage
 
+			if err := gWriterCtx.Err(); err != nil {
+				// Stop processing
+				break
+			}
+
 			// Acquire a token
 			if err := sem.Acquire(gWriterCtx, 1); err != nil {
 				return fmt.Errorf("unable to acquire a semaphore token: %w", err)
@@ -99,6 +104,11 @@ func (op *importer) Run(ctx context.Context) error {
 			// Build function reader
 			gWriter.Go(func() error {
 				defer sem.Release(1)
+
+				if err := gWriterCtx.Err(); err != nil {
+					// Context has already an error
+					return nil
+				}
 
 				// No data to insert
 				if secretPackage.Secrets == nil {

--- a/pkg/bundle/vault/push.go
+++ b/pkg/bundle/vault/push.go
@@ -93,7 +93,7 @@ func runPush(ctx context.Context, b *bundlev1.Bundle, client *api.Client, opts *
 
 	// Run the vault operation
 	if err := op.Run(ctx); err != nil {
-		return fmt.Errorf("unable to import secret bundle: %w", err)
+		return fmt.Errorf("unable to push secret bundle: %w", err)
 	}
 
 	// No error

--- a/pkg/tasks/from/vault.go
+++ b/pkg/tasks/from/vault.go
@@ -26,6 +26,7 @@ import (
 	"github.com/elastic/harp/pkg/bundle"
 	bundlevault "github.com/elastic/harp/pkg/bundle/vault"
 	"github.com/elastic/harp/pkg/tasks"
+	"github.com/elastic/harp/pkg/vault"
 )
 
 // VaultTask implements secret-container building from Vault K/V.
@@ -48,6 +49,11 @@ func (t *VaultTask) Run(ctx context.Context) error {
 	// If a namespace is specified
 	if t.VaultNamespace != "" {
 		client.SetNamespace(t.VaultNamespace)
+	}
+
+	// Verify vault connection
+	if _, err := vault.CheckAuthentication(client); err != nil {
+		return fmt.Errorf("vault connection verification failed: %w", err)
 	}
 
 	// Call exporter

--- a/pkg/tasks/to/vault.go
+++ b/pkg/tasks/to/vault.go
@@ -26,6 +26,7 @@ import (
 	"github.com/elastic/harp/pkg/bundle"
 	bundlevault "github.com/elastic/harp/pkg/bundle/vault"
 	"github.com/elastic/harp/pkg/tasks"
+	"github.com/elastic/harp/pkg/vault"
 )
 
 // VaultTask implements secret-container publication process to Vault.
@@ -48,6 +49,11 @@ func (t *VaultTask) Run(ctx context.Context) error {
 	// If a namespace is specified
 	if t.VaultNamespace != "" {
 		client.SetNamespace(t.VaultNamespace)
+	}
+
+	// Verify vault connection
+	if _, err := vault.CheckAuthentication(client); err != nil {
+		return fmt.Errorf("vault connection verification failed: %w", err)
 	}
 
 	// Create the reader

--- a/pkg/vault/helpers.go
+++ b/pkg/vault/helpers.go
@@ -1,0 +1,43 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package vault
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/vault/api"
+)
+
+// -----------------------------------------------------------------------------
+
+// CheckAuthentication verifies that the connection to vault is setup correctly
+// by retrieving information about the configured token
+func CheckAuthentication(client *api.Client) ([]string, error) {
+	tokenInfo, tokenErr := client.Auth().Token().LookupSelf()
+	if tokenErr != nil {
+		return nil, fmt.Errorf("error connecting to vault: %w", tokenErr)
+	}
+
+	tokenPolicies, polErr := tokenInfo.TokenPolicies()
+	if polErr != nil {
+		return nil, fmt.Errorf("error looking up token policies: %w", tokenErr)
+	}
+
+	// No error
+	return tokenPolicies, nil
+}


### PR DESCRIPTION
# Context

Vault error was masked by an invalid errorgroup usage.