### PR TITLE
Chore go116rc1

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -30,6 +30,7 @@ tasks:
     cmds:
       - rm -rf dist && mkdir dist
       - "tar cfJ dist/{{.ARTIFACT}}-darwin-amd64-$RELEASE.tar.xz -C bin {{.ARTIFACT}}-darwin-amd64"
+      - "tar cfJ dist/{{.ARTIFACT}}-darwin-arm64-$RELEASE.tar.xz -C bin {{.ARTIFACT}}-darwin-arm64"
       - "tar cfJ dist/{{.ARTIFACT}}-linux-amd64-$RELEASE.tar.xz -C bin {{.ARTIFACT}}-linux-amd64"
       - "tar cfJ dist/{{.ARTIFACT}}-linux-arm7-$RELEASE.tar.xz -C bin {{.ARTIFACT}}-linux-arm7"
       - "tar cfJ dist/{{.ARTIFACT}}-linux-arm64-$RELEASE.tar.xz -C bin {{.ARTIFACT}}-linux-arm64"

--- a/build/mage/golang/init.go
+++ b/build/mage/golang/init.go
@@ -29,6 +29,7 @@ import (
 
 // Keep only last 2 versions
 var goVersions = []string{
+	"go1.16rc1",
 	"go1.15.6",
 	"go1.15.7",
 }

--- a/cmd/harp-server/Taskfile.yml
+++ b/cmd/harp-server/Taskfile.yml
@@ -29,6 +29,7 @@ tasks:
     cmds:
       - rm -rf dist && mkdir dist
       - "tar cfJ dist/{{.ARTIFACT}}-darwin-amd64-$RELEASE.tar.xz -C bin {{.ARTIFACT}}-darwin-amd64"
+      - "tar cfJ dist/{{.ARTIFACT}}-darwin-arm64-$RELEASE.tar.xz -C bin {{.ARTIFACT}}-darwin-arm64"
       - "tar cfJ dist/{{.ARTIFACT}}-linux-amd64-$RELEASE.tar.xz -C bin {{.ARTIFACT}}-linux-amd64"
       - "tar cfJ dist/{{.ARTIFACT}}-linux-arm7-$RELEASE.tar.xz -C bin {{.ARTIFACT}}-linux-arm7"
       - "tar cfJ dist/{{.ARTIFACT}}-linux-arm64-$RELEASE.tar.xz -C bin {{.ARTIFACT}}-linux-arm64"

--- a/cmd/harp-server/magefile.go
+++ b/cmd/harp-server/magefile.go
@@ -126,6 +126,14 @@ func Release(ctx context.Context) error {
 				"harp-server",
 				"github.com/elastic/harp/cmd/harp-server",
 				version,
+				golang.GOOS("darwin"), golang.GOARCH("arm64"),
+			)()
+		},
+		func() error {
+			return golang.Release(
+				"harp-server",
+				"github.com/elastic/harp/cmd/harp-server",
+				version,
 				golang.GOOS("linux"), golang.GOARCH("amd64"),
 			)()
 		},

--- a/magefile.go
+++ b/magefile.go
@@ -197,6 +197,14 @@ func Release(ctx context.Context) error {
 				"harp",
 				"github.com/elastic/harp/cmd/harp",
 				version,
+				golang.GOOS("darwin"), golang.GOARCH("arm64"),
+			)()
+		},
+		func() error {
+			return golang.Release(
+				"harp",
+				"github.com/elastic/harp/cmd/harp",
+				version,
 				golang.GOOS("linux"), golang.GOARCH("amd64"),
 			)()
 		},


### PR DESCRIPTION
# Context

Setup go toolchain to use `go1.16` current version (go1.1.6rc1)  to support native Darwin ARM64 architecture in order to get native M1 supported binaries.