### PR TITLE
fix(fuzz): memguard random race condition during fuzz

### DIFF
--- a/pkg/container/codec_test.go
+++ b/pkg/container/codec_test.go
@@ -361,7 +361,7 @@ func Test_UnSeal_Fuzz(t *testing.T) {
 		f := fuzz.New()
 
 		// Prepare arguments
-		var identity []byte
+		var identity [32]byte
 		input := containerv1.Container{
 			Headers: &containerv1.Header{},
 			Raw:     []byte{0x00, 0x00},
@@ -372,6 +372,6 @@ func Test_UnSeal_Fuzz(t *testing.T) {
 		f.Fuzz(&identity)
 
 		// Execute
-		Unseal(&input, memguard.NewBufferFromBytes(identity))
+		Unseal(&input, memguard.NewBufferFromBytes(identity[:]))
 	}
 }


### PR DESCRIPTION
# Context

`memguard` (software enclave) could raise an error during speed fuzz. Identity is a 32bytes long byte array but the test was unbounded to the desired identity size.
I suspect that fuzz could allocate a very big byte array that could crash the test.

```
12:06:32  #18 105.3 === Failed
12:06:32  #18 105.3 === FAIL: pkg/container Test_UnSeal_Fuzz (0.01s)
12:06:32  #18 105.3 panic: <memcall> could not acquire lock on 0x7f3e94b03000, limit reached? [Err: cannot allocate memory] [recovered]
12:06:32  #18 105.3 	panic: <memcall> could not acquire lock on 0x7f3e94b03000, limit reached? [Err: cannot allocate memory]
12:06:32  #18 105.3 
12:06:32  #18 105.3 goroutine 59 [running]:
12:06:32  #18 105.3 testing.tRunner.func1.1(0x86c3a0, 0xc00018db40)
12:06:32  #18 105.3 	/usr/local/go/src/testing/testing.go:1072 +0x46a
12:06:32  #18 105.3 testing.tRunner.func1(0xc000082f00)
12:06:32  #18 105.3 	/usr/local/go/src/testing/testing.go:1075 +0x636
12:06:32  #18 105.3 panic(0x86c3a0, 0xc00018db40)
12:06:32  #18 105.3 	/usr/local/go/src/runtime/panic.go:975 +0x47a
12:06:32  #18 105.3 github.com/awnumar/memguard/core.Panic(0x86c3a0, 0xc00018db40)
12:06:32  #18 105.3 	/go/src/workspace/vendor/github.com/awnumar/memguard/core/exit.go:86 +0x48
12:06:32  #18 105.3 github.com/awnumar/memguard/core.NewBuffer(0x5, 0xc000111e10, 0x82821c, 0xc00018db30)
12:06:32  #18 105.3 	/go/src/workspace/vendor/github.com/awnumar/memguard/core/buffer.go:75 +0x8e8
12:06:32  #18 105.3 github.com/awnumar/memguard.NewBuffer(0x5, 0xc00018db30)
12:06:32  #18 105.3 	/go/src/workspace/vendor/github.com/awnumar/memguard/buffer.go:47 +0x3d
12:06:32  #18 105.3 github.com/awnumar/memguard.NewBufferFromBytes(0xc0001e5854, 0x5, 0x5, 0x926060)
12:06:32  #18 105.3 	/go/src/workspace/vendor/github.com/awnumar/memguard/buffer.go:61 +0x3d
12:06:32  #18 105.3 github.com/elastic/harp/pkg/container.Test_UnSeal_Fuzz(0xc000082f00)
12:06:32  #18 105.3 	/go/src/workspace/pkg/container/codec_test.go:375 +0xec
12:06:32  #18 105.3 testing.tRunner(0xc000082f00, 0x8cee68)
12:06:32  #18 105.3 	/usr/local/go/src/testing/testing.go:1123 +0x203
12:06:32  #18 105.3 created by testing.(*T).Run
12:06:32  #18 105.3 	/usr/local/go/src/testing/testing.go:1168 +0x5bc
12:06:32  #18 105.3 
12:06:32  #18 105.3 DONE 454 tests, 1 failure in 62.420s
12:06:32  #18 105.3 Error: running "gotestsum --junitfile test-results/junit/unit-b9f3a7528eeecff3d8e6b898feb6b5e35ee165733d5e7bbe2866bde6f28787b2.xml -- -short -race -cover github.com/elastic/harp/pkg/..." failed with exit code 1
12:06:32  #18 ERROR: executor failed running [/bin/sh -c set -eux;     mage]: exit code: 1
```
