### PR TITLE
fix(test): fix fuzz tests with memguard.

### DIFF
--- a/pkg/container/codec_test.go
+++ b/pkg/container/codec_test.go
@@ -356,12 +356,15 @@ func Test_Seal_Fuzz(t *testing.T) {
 }
 
 func Test_UnSeal_Fuzz(t *testing.T) {
+	// Memguard buffer is excluded from fuzz for random race condition error
+	// investigation will be done in a separated thread.
+	identity := memguard.NewBufferRandom(32)
+
 	// Making sure the function never panics
 	for i := 0; i < 500; i++ {
 		f := fuzz.New()
 
 		// Prepare arguments
-		var identity [32]byte
 		input := containerv1.Container{
 			Headers: &containerv1.Header{},
 			Raw:     []byte{0x00, 0x00},
@@ -369,9 +372,8 @@ func Test_UnSeal_Fuzz(t *testing.T) {
 
 		f.Fuzz(&input.Headers)
 		f.Fuzz(&input.Raw)
-		f.Fuzz(&identity)
 
 		// Execute
-		Unseal(&input, memguard.NewBufferFromBytes(identity[:]))
+		Unseal(&input, identity)
 	}
 }


### PR DESCRIPTION
# Context

Fuzz tests with memguard randomly generate 1 issue. This is the second attempt to fix this test.

```
09:18:46  #18 98.46 === Failed
09:18:46  #18 98.46 === FAIL: pkg/container Test_UnSeal_Fuzz (0.01s)
09:18:46  #18 98.46 panic: <memcall> could not acquire lock on 0x7f94c851c000, limit reached? [Err: cannot allocate memory] [recovered]
09:18:46  #18 98.46 	panic: <memcall> could not acquire lock on 0x7f94c851c000, limit reached? [Err: cannot allocate memory]
09:18:46  #18 98.46 
09:18:46  #18 98.46 goroutine 6 [running]:
09:18:46  #18 98.46 testing.tRunner.func1.1(0x86c3a0, 0xc00011b010)
09:18:46  #18 98.46 	/usr/local/go/src/testing/testing.go:1072 +0x46a
09:18:46  #18 98.46 testing.tRunner.func1(0xc0001d3200)
09:18:46  #18 98.46 	/usr/local/go/src/testing/testing.go:1075 +0x636
09:18:46  #18 98.46 panic(0x86c3a0, 0xc00011b010)
09:18:46  #18 98.46 	/usr/local/go/src/runtime/panic.go:975 +0x47a
09:18:46  #18 98.46 github.com/awnumar/memguard/core.Panic(0x86c3a0, 0xc00011b010)
09:18:46  #18 98.46 	/go/src/workspace/vendor/github.com/awnumar/memguard/core/exit.go:86 +0x48
09:18:46  #18 98.46 github.com/awnumar/memguard/core.NewBuffer(0x20, 0xc00012fe10, 0x82821c, 0xc00011b000)
09:18:46  #18 98.46 	/go/src/workspace/vendor/github.com/awnumar/memguard/core/buffer.go:75 +0x8e8
09:18:46  #18 98.46 github.com/awnumar/memguard.NewBuffer(0x20, 0xc00011b000)
09:18:46  #18 98.46 	/go/src/workspace/vendor/github.com/awnumar/memguard/buffer.go:47 +0x3d
09:18:46  #18 98.46 github.com/awnumar/memguard.NewBufferFromBytes(0xc00023a680, 0x20, 0x20, 0x926060)
09:18:46  #18 98.46 	/go/src/workspace/vendor/github.com/awnumar/memguard/buffer.go:61 +0x3d
09:18:46  #18 98.46 github.com/elastic/harp/pkg/container.Test_UnSeal_Fuzz(0xc0001d3200)
09:18:46  #18 98.46 	/go/src/workspace/pkg/container/codec_test.go:375 +0xdb
09:18:46  #18 98.46 testing.tRunner(0xc0001d3200, 0x8cee68)
09:18:46  #18 98.46 	/usr/local/go/src/testing/testing.go:1123 +0x203
09:18:46  #18 98.46 created by testing.(*T).Run
09:18:46  #18 98.46 	/usr/local/go/src/testing/testing.go:1168 +0x5bc
09:18:46  #18 98.46 
09:18:46  #18 98.46 DONE 458 tests, 1 failure in 59.254s
09:18:46  #18 98.47 Error: running "gotestsum --junitfile test-results/junit/unit-b9f3a7528eeecff3d8e6b898feb6b5e35ee165733d5e7bbe2866bde6f28787b2.xml -- -short -race -cover github.com/elastic/harp/pkg/..." failed with exit code 1
09:18:46  #18 ERROR: executor failed running [/bin/sh -c set -eux;     mage]: exit code: 1
```