### PR TITLE
fix(lint): errorlint for harp-server.

### DIFF
--- a/cmd/harp-server/internal/dispatchers/http/routes/backend.go
+++ b/cmd/harp-server/internal/dispatchers/http/routes/backend.go
@@ -18,6 +18,7 @@
 package routes
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -43,7 +44,7 @@ func backend(namespace string, engine storage.Engine) http.HandlerFunc {
 
 		// Retrieve secret from engine
 		secret, err := engine.Get(ctx, identifier)
-		if err == storage.ErrSecretNotFound {
+		if errors.Is(err, storage.ErrSecretNotFound) {
 			http.Error(w, "secret not found", http.StatusNotFound)
 			return
 		}

--- a/cmd/harp-server/internal/dispatchers/vault/routes/kv.go
+++ b/cmd/harp-server/internal/dispatchers/vault/routes/kv.go
@@ -19,6 +19,7 @@ package routes
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 
@@ -88,7 +89,7 @@ func (h *vaultKVHandler) getSecret() http.HandlerFunc {
 
 		// Retrieve secret from engine
 		secret, err := h.bm.GetSecret(ctx, vpath.SanitizePath(ns), p)
-		if err == storage.ErrSecretNotFound {
+		if errors.Is(err, storage.ErrSecretNotFound) {
 			http.Error(w, "secret not found", http.StatusNotFound)
 			return
 		}


### PR DESCRIPTION
# Context

`golang-ci` raised 2 errorlint in `harp-server`.