### PR TITLE
Feat vault version puller

### DIFF
--- a/pkg/bundle/vault/internal/operation/api.go
+++ b/pkg/bundle/vault/internal/operation/api.go
@@ -27,5 +27,8 @@ type Operation interface {
 }
 
 const (
-	bundleMetadataPrefix = "harp.elastic.io/v1/bundle"
+	bundleMetadataPrefix         = "harp.elastic.io/v1/bundle"
+	vaultKVMetadata              = "www.vaultproject.io/kv/metadata"
+	vaultKVv2MetadataVersion     = "www.vaultproject.io/kv/v2/metadata#version"
+	vaultKVv2MetadataCreatedTime = "www.vaultproject.io/kv/v2/metadata#createdTime"
 )

--- a/pkg/bundle/vault/internal/operation/exporter.go
+++ b/pkg/bundle/vault/internal/operation/exporter.go
@@ -111,13 +111,13 @@ func (op *exporter) Run(ctx context.Context) error {
 				}
 
 				// Extract desired version from path
-				vaultPath, vaultVersion, errPackagePath := extractVersion(secPath)
+				vaultPackagePath, vaultVersion, errPackagePath := extractVersion(secPath)
 				if errPackagePath != nil {
 					return fmt.Errorf("unable to parse package path '%s': %w", secPath, errPackagePath)
 				}
 
 				// Read from Vault
-				secretData, secretMeta, err := op.service.ReadVersion(gReaderCtx, vaultPath, vaultVersion)
+				secretData, secretMeta, err := op.service.ReadVersion(gReaderCtx, vaultPackagePath, vaultVersion)
 				if err != nil {
 					// Mask path not found or empty secret value
 					if errors.Is(err, kv.ErrNoData) || errors.Is(err, kv.ErrPathNotFound) {
@@ -162,7 +162,7 @@ func (op *exporter) Run(ctx context.Context) error {
 				pack := &bundlev1.Package{
 					Labels:      map[string]string{},
 					Annotations: map[string]string{},
-					Name:        vaultPath,
+					Name:        vaultPackagePath,
 					Secrets:     chain,
 				}
 

--- a/pkg/bundle/vault/internal/operation/exporter.go
+++ b/pkg/bundle/vault/internal/operation/exporter.go
@@ -161,7 +161,7 @@ func (op *exporter) Run(ctx context.Context) error {
 				pack := &bundlev1.Package{
 					Labels:      map[string]string{},
 					Annotations: map[string]string{},
-					Name:        secPath,
+					Name:        vaultPath,
 					Secrets:     chain,
 				}
 

--- a/pkg/bundle/vault/internal/operation/exporter_test.go
+++ b/pkg/bundle/vault/internal/operation/exporter_test.go
@@ -1,0 +1,87 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package operation
+
+import (
+	"testing"
+)
+
+func Test_extractVersion(t *testing.T) {
+	type args struct {
+		packagePath string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		want1   uint
+		wantErr bool
+	}{
+		{
+			name:    "blank",
+			wantErr: true,
+		},
+		{
+			name: "no version",
+			args: args{
+				packagePath: "app/test",
+			},
+			wantErr: false,
+			want:    "app/test",
+			want1:   0,
+		},
+		{
+			name: "with version",
+			args: args{
+				packagePath: "app/test?version=14",
+			},
+			wantErr: false,
+			want:    "app/test",
+			want1:   14,
+		},
+		{
+			name: "with invalid version",
+			args: args{
+				packagePath: "app/test?version=azerty",
+			},
+			wantErr: true,
+		},
+		{
+			name: "with invalid path",
+			args: args{
+				packagePath: "\n\t",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, err := extractVersion(tt.args.packagePath)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("exporter.extractVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("exporter.extractVersion() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("exporter.extractVersion() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}

--- a/pkg/bundle/vault/internal/operation/importer.go
+++ b/pkg/bundle/vault/internal/operation/importer.go
@@ -178,7 +178,7 @@ func (op *importer) Run(ctx context.Context) error {
 
 				// Write secret to Vault
 				if err := op.backends[rootPath].Write(gWriterCtx, secretPath, data); err != nil {
-					return fmt.Errorf("unbale to write secret data for path '%s': %w", secretPath, err)
+					return fmt.Errorf("unable to write secret data for path '%s': %w", secretPath, err)
 				}
 
 				// No error

--- a/pkg/server/storage/backends/vault/engine.go
+++ b/pkg/server/storage/backends/vault/engine.go
@@ -69,17 +69,17 @@ func init() {
 
 func (e *engine) Get(ctx context.Context, id string) ([]byte, error) {
 	// Read from Vault
-	secret, err := e.service.Read(ctx, id)
+	secretData, _, err := e.service.Read(ctx, id)
 	if err != nil {
 		return nil, fmt.Errorf("vault: unable to read secret from vault server: %w", err)
 	}
-	if secret == nil {
+	if secretData == nil {
 		return []byte{}, storage.ErrSecretNotFound
 	}
 
 	// Encode secret as json
 	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(secret); err != nil {
+	if err := json.NewEncoder(&buf).Encode(secretData); err != nil {
 		return nil, fmt.Errorf("vault: unable to encode secret: %w", err)
 	}
 

--- a/pkg/vault/kv/api.go
+++ b/pkg/vault/kv/api.go
@@ -43,6 +43,7 @@ type SecretLister interface {
 // SecretReader represents secret reader feature contract.
 type SecretReader interface {
 	Read(ctx context.Context, path string) (SecretData, SecretMetadata, error)
+	ReadVersion(ctx context.Context, path string, version uint) (SecretData, SecretMetadata, error)
 }
 
 // SecretWriter represents secret writer feature contract.

--- a/pkg/vault/kv/api.go
+++ b/pkg/vault/kv/api.go
@@ -29,8 +29,11 @@ var (
 	ErrNoData = errors.New("no data")
 )
 
-// Secrets is a secret body
-type Secrets map[string]interface{}
+// SecretData is a secret body
+type SecretData map[string]interface{}
+
+// SecretMetadata is secret data attached metadata
+type SecretMetadata map[string]interface{}
 
 // SecretLister repesents secret key listing feature contract.
 type SecretLister interface {
@@ -39,12 +42,12 @@ type SecretLister interface {
 
 // SecretReader represents secret reader feature contract.
 type SecretReader interface {
-	Read(ctx context.Context, path string) (Secrets, error)
+	Read(ctx context.Context, path string) (SecretData, SecretMetadata, error)
 }
 
 // SecretWriter represents secret writer feature contract.
 type SecretWriter interface {
-	Write(ctx context.Context, path string, secrets Secrets) error
+	Write(ctx context.Context, path string, secrets SecretData) error
 }
 
 // Service declares vault service contract.

--- a/pkg/vault/kv/builder_test.go
+++ b/pkg/vault/kv/builder_test.go
@@ -82,7 +82,7 @@ func TestBuilder_V1(t *testing.T) {
 	}
 
 	// Read the value
-	_, err = underTest.Read(context.Background(), "application/secret/foo")
+	_, _, err = underTest.Read(context.Background(), "application/secret/foo")
 	if err != nil {
 		t.Errorf("BuilderV1() - Read error = %v", err)
 		return
@@ -112,7 +112,7 @@ func TestBuilder_V2(t *testing.T) {
 			switch r.Method {
 			case http.MethodGet:
 				w.WriteHeader(200)
-				fmt.Fprintf(w, `{"data":{"data":{"key":"value"}}}`)
+				fmt.Fprintf(w, `{"data":{"data":{"key":"value"},"metadata":{"created_time": "2018-03-22T02:24:06.945319214Z","deletion_time": "","destroyed": false,"version": 2}}}`)
 			case http.MethodPut:
 				w.WriteHeader(200)
 				fmt.Fprintf(w, `{"data":{"data":{}}}`)
@@ -152,7 +152,7 @@ func TestBuilder_V2(t *testing.T) {
 	}
 
 	// Read the value
-	_, err = underTest.Read(context.Background(), "application/secret/foo")
+	_, _, err = underTest.Read(context.Background(), "application/secret/foo")
 	if err != nil {
 		t.Errorf("BuilderV2() - Read error = %v", err)
 		return

--- a/pkg/vault/kv/secret_reader.go
+++ b/pkg/vault/kv/secret_reader.go
@@ -36,6 +36,7 @@ func SecretGetter(client *api.Client) func(string) (map[string]interface{}, erro
 		}
 
 		// Delegate to reader
-		return service.Read(context.Background(), path)
+		data, _, err := service.Read(context.Background(), path)
+		return data, err
 	}
 }

--- a/pkg/vault/kv/secret_reader_test.go
+++ b/pkg/vault/kv/secret_reader_test.go
@@ -73,7 +73,7 @@ func TestSecretReader_Found(t *testing.T) {
 			fmt.Fprintf(w, `{"data":{"type":"kv", "path":"application/", "options":{"version": "2"}}}`)
 		case "/v1/application/data/secret/found":
 			w.WriteHeader(200)
-			fmt.Fprintf(w, `{"data":{"data":{"key":"value"}}}`)
+			fmt.Fprintf(w, `{"data":{"data":{"key":"value"},"metadata":{}}}`)
 		default:
 			w.WriteHeader(400)
 		}

--- a/pkg/vault/kv/v1_service.go
+++ b/pkg/vault/kv/v1_service.go
@@ -81,30 +81,30 @@ func (s *kvv1Backend) List(ctx context.Context, path string) ([]string, error) {
 	return out, nil
 }
 
-func (s *kvv1Backend) Read(ctx context.Context, path string) (Secrets, error) {
+func (s *kvv1Backend) Read(ctx context.Context, path string) (SecretData, SecretMetadata, error) {
 	// Clean path first
 	secretPath := vpath.SanitizePath(path)
 	if secretPath == "" {
-		return nil, fmt.Errorf("unable to query with empty path")
+		return nil, nil, fmt.Errorf("unable to query with empty path")
 	}
 
 	// Create a logical client
 	secret, err := s.logical.Read(secretPath)
 	if err != nil {
-		return nil, fmt.Errorf("unable to retrieve secret for path '%s': %w", path, err)
+		return nil, nil, fmt.Errorf("unable to retrieve secret for path '%s': %w", path, err)
 	}
 	if secret == nil {
-		return nil, fmt.Errorf("unable to retrieve secret for path '%s': %w", path, ErrPathNotFound)
+		return nil, nil, fmt.Errorf("unable to retrieve secret for path '%s': %w", path, ErrPathNotFound)
 	}
 	if secret.Data == nil {
-		return nil, fmt.Errorf("unable to retrieve secret for path '%s': %w", path, ErrNoData)
+		return nil, nil, fmt.Errorf("unable to retrieve secret for path '%s': %w", path, ErrNoData)
 	}
 
 	// Return secret value and no error
-	return secret.Data, nil
+	return secret.Data, nil, err
 }
 
-func (s *kvv1Backend) Write(ctx context.Context, path string, data Secrets) error {
+func (s *kvv1Backend) Write(ctx context.Context, path string, data SecretData) error {
 	// Clean path first
 	secretPath := vpath.SanitizePath(path)
 	if secretPath == "" {

--- a/pkg/vault/kv/v1_service.go
+++ b/pkg/vault/kv/v1_service.go
@@ -104,6 +104,10 @@ func (s *kvv1Backend) Read(ctx context.Context, path string) (SecretData, Secret
 	return secret.Data, nil, err
 }
 
+func (s *kvv1Backend) ReadVersion(ctx context.Context, path string, version uint) (SecretData, SecretMetadata, error) {
+	return s.Read(ctx, path)
+}
+
 func (s *kvv1Backend) Write(ctx context.Context, path string, data SecretData) error {
 	// Clean path first
 	secretPath := vpath.SanitizePath(path)

--- a/pkg/vault/kv/v1_service_test.go
+++ b/pkg/vault/kv/v1_service_test.go
@@ -91,7 +91,7 @@ func Test_KVV1_List(t *testing.T) {
 			},
 			prepare: func(logical *logical.MockLogical) {
 				logical.EXPECT().List("secrets/application/foo").Return(&vaultApi.Secret{
-					Data: Secrets{},
+					Data: SecretData{},
 				}, nil)
 			},
 			wantErr: true,
@@ -104,7 +104,7 @@ func Test_KVV1_List(t *testing.T) {
 			},
 			prepare: func(logical *logical.MockLogical) {
 				logical.EXPECT().List("secrets/application/foo").Return(&vaultApi.Secret{
-					Data: Secrets{
+					Data: SecretData{
 						"keys": 1,
 					},
 				}, nil)
@@ -119,7 +119,7 @@ func Test_KVV1_List(t *testing.T) {
 			},
 			prepare: func(logical *logical.MockLogical) {
 				logical.EXPECT().List("secrets/application/foo").Return(&vaultApi.Secret{
-					Data: Secrets{
+					Data: SecretData{
 						"keys": []interface{}{},
 					},
 				}, nil)
@@ -135,7 +135,7 @@ func Test_KVV1_List(t *testing.T) {
 			},
 			prepare: func(logical *logical.MockLogical) {
 				logical.EXPECT().List("secrets/application/foo").Return(&vaultApi.Secret{
-					Data: Secrets{
+					Data: SecretData{
 						"keys": []interface{}{"secrets/application/foo/secret-1", "secrets/application/foo/secret-2"},
 					},
 				}, nil)
@@ -180,11 +180,12 @@ func Test_KVV1_Read(t *testing.T) {
 		path string
 	}
 	tests := []struct {
-		name    string
-		prepare func(*logical.MockLogical)
-		args    args
-		want    Secrets
-		wantErr bool
+		name     string
+		prepare  func(*logical.MockLogical)
+		args     args
+		wantData SecretData
+		wantMeta SecretMetadata
+		wantErr  bool
 	}{
 		{
 			name: "nil",
@@ -237,13 +238,13 @@ func Test_KVV1_Read(t *testing.T) {
 			},
 			prepare: func(logical *logical.MockLogical) {
 				logical.EXPECT().Read("secrets/application/foo").Return(&vaultApi.Secret{
-					Data: Secrets{
+					Data: SecretData{
 						"key": "value",
 					},
 				}, nil)
 			},
 			wantErr: false,
-			want: Secrets{
+			wantData: SecretData{
 				"key": "value",
 			},
 		},
@@ -263,13 +264,16 @@ func Test_KVV1_Read(t *testing.T) {
 
 			// Service
 			underTest := V1(logicalMock, "secrets/")
-			got, err := underTest.Read(tt.args.ctx, tt.args.path)
+			gotData, gotMeta, err := underTest.Read(tt.args.ctx, tt.args.path)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("vaultClient.Read() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !tt.wantErr && !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("vaultClient.Read() = %v, want %v", got, tt.want)
+			if !tt.wantErr && !reflect.DeepEqual(gotData, tt.wantData) {
+				t.Errorf("vaultClient.Read() = %v, want %v", gotData, tt.wantData)
+			}
+			if !tt.wantErr && !reflect.DeepEqual(gotMeta, tt.wantMeta) {
+				t.Errorf("vaultClient.Read() = %v, want %v", gotMeta, tt.wantMeta)
 			}
 		})
 	}
@@ -314,7 +318,7 @@ func Test_vaultClient_Write(t *testing.T) {
 			},
 			prepare: func(logical *logical.MockLogical) {
 				logical.EXPECT().Write("secrets/application/foo", gomock.Any()).Return(&vaultApi.Secret{
-					Data: Secrets{
+					Data: SecretData{
 						"key": "value",
 					},
 				}, nil)

--- a/pkg/vault/logical/api.go
+++ b/pkg/vault/logical/api.go
@@ -24,6 +24,7 @@ import "github.com/hashicorp/vault/api"
 // Logical backend interface
 type Logical interface {
 	Read(path string) (*api.Secret, error)
+	ReadWithData(path string, data map[string][]string) (*api.Secret, error)
 	Write(path string, data map[string]interface{}) (*api.Secret, error)
 	List(path string) (*api.Secret, error)
 }


### PR DESCRIPTION
# Context

* Add the ability to export a given secret version from Vault
* Export Vault KV metadata as annotations and set the `packages[].secrets.version` value

> Using version on a fuzzy path matcher wil not work and return an `empty` secret set.

## Sample

### View metadata from a bundle created from `vault`

```
$ harp from vault --path app/production/customer1/ece/v1.0.0/userconsole/http/session | harp bundle dump | jq
{
  "packages": [
    {
      "annotations": {
        "www.vaultproject.io/kv/metadata": "{\"created_time\":\"2021-02-05T10:58:25.353833Z\",\"deletion_time\":\"\",\"destroyed\":false,\"version\":2}",
        "www.vaultproject.io/kv/v2/metadata#createdTime": "2021-02-05T10:58:25.353833Z",
        "www.vaultproject.io/kv/v2/metadata#version": "2"
      },
      "name": "app/production/customer1/ece/v1.0.0/userconsole/http/session",
      "secrets": {
        "version": 2,
        "data": [
           .. REDACTED ..
        ]
      }
    }
  ],
  "merkleTreeRoot": "LHLZjdk0ca6VPpD1mDwqJZ++lAKOdHhW+42N2262DSwy57Lv+3WwQsiYY6X+Fuiqurr1zQhrcIAiYAkzk7nCgA=="
}
```

### Pull a given version of a secret

```
harp from vault --path app/production/customer1/ece/v1.0.0/userconsole/http/session\?version=1 | harp bundle dump
{
  "packages": [
    {
      "annotations": {
        "www.vaultproject.io/kv/metadata": "{\"created_time\":\"2021-02-05T10:52:03.050403Z\",\"deletion_time\":\"\",\"destroyed\":false,\"version\":1}",
        "www.vaultproject.io/kv/v2/metadata#createdTime": "2021-02-05T10:52:03.050403Z",
        "www.vaultproject.io/kv/v2/metadata#version": "1"
      },
      "name": "/app/production/customer1/ece/v1.0.0/userconsole/http/session",
      "secrets": {
        "version": 1,
        "data": [
          .. REDACTED ..
        ]
      }
    }
  ],
  "merkleTreeRoot": "ZhHJOvboXFsS2CYP0Ji8FGWg6PBjP0xNDbNA1ds8lagW1ZRYHO22HfP/0Z18O++GhBcneWacPLnwevM+BtnWig=="
}
```

### Compound bundle with specific versions

```
$ harp from vault --path app/production | harp bundle dump --path-only > mypaths.txt
app/production/customer1/ece/v1.0.0/adminconsole/authentication/otp/okta_api_key
app/production/customer1/ece/v1.0.0/adminconsole/database/usage_credentials
app/production/customer1/ece/v1.0.0/adminconsole/http/session
app/production/customer1/ece/v1.0.0/adminconsole/mailing/sender/mailgun_api_key
app/production/customer1/ece/v1.0.0/adminconsole/privacy/anonymizer
app/production/customer1/ece/v1.0.0/userconsole/database/usage_credentials
app/production/customer1/ece/v1.0.0/userconsole/http/certificate
app/production/customer1/ece/v1.0.0/userconsole/http/session
```

Update your paths

```diff
app/production/customer1/ece/v1.0.0/adminconsole/authentication/otp/okta_api_key
- app/production/customer1/ece/v1.0.0/adminconsole/database/usage_credentials
+ app/production/customer1/ece/v1.0.0/adminconsole/database/usage_credentials?version=8
app/production/customer1/ece/v1.0.0/adminconsole/http/session
app/production/customer1/ece/v1.0.0/adminconsole/mailing/sender/mailgun_api_key
app/production/customer1/ece/v1.0.0/adminconsole/privacy/anonymizer
app/production/customer1/ece/v1.0.0/userconsole/database/usage_credentials
app/production/customer1/ece/v1.0.0/userconsole/http/certificate
app/production/customer1/ece/v1.0.0/userconsole/http/session
```

Pull a bundle using your paths

```
$ harp from vault --path-from mypaths.txt --out mycompound.bundle
```