### PR TITLE
fix(codeql): invalid integer parsing.

### DIFF
--- a/pkg/bundle/vault/internal/operation/exporter.go
+++ b/pkg/bundle/vault/internal/operation/exporter.go
@@ -306,7 +306,7 @@ func (op *exporter) packSecret(key string, value interface{}) (*bundlev1.KV, err
 	}, nil
 }
 
-func extractVersion(packagePath string) (string, uint, error) {
+func extractVersion(packagePath string) (string, uint32, error) {
 	// Check arguments
 	if packagePath == "" {
 		return "", 0, fmt.Errorf("unable to extract path and version from an empty string")
@@ -326,11 +326,11 @@ func extractVersion(packagePath string) (string, uint, error) {
 	}
 
 	// Convert
-	versionUnit, errParse := strconv.ParseUint(versionRaw, 10, 64)
+	versionUnit, errParse := strconv.ParseUint(versionRaw, 10, 32)
 	if errParse != nil {
 		return "", 0, fmt.Errorf("unable to parse version as a valid integer: %w", err)
 	}
 
 	// Return path elements
-	return vaultPath.SanitizePath(u.Path), uint(versionUnit), nil
+	return vaultPath.SanitizePath(u.Path), uint32(versionUnit), nil
 }

--- a/pkg/bundle/vault/internal/operation/exporter_test.go
+++ b/pkg/bundle/vault/internal/operation/exporter_test.go
@@ -29,7 +29,7 @@ func Test_extractVersion(t *testing.T) {
 		name    string
 		args    args
 		want    string
-		want1   uint
+		want1   uint32
 		wantErr bool
 	}{
 		{

--- a/pkg/vault/kv/api.go
+++ b/pkg/vault/kv/api.go
@@ -43,7 +43,7 @@ type SecretLister interface {
 // SecretReader represents secret reader feature contract.
 type SecretReader interface {
 	Read(ctx context.Context, path string) (SecretData, SecretMetadata, error)
-	ReadVersion(ctx context.Context, path string, version uint) (SecretData, SecretMetadata, error)
+	ReadVersion(ctx context.Context, path string, version uint32) (SecretData, SecretMetadata, error)
 }
 
 // SecretWriter represents secret writer feature contract.

--- a/pkg/vault/kv/v1_service.go
+++ b/pkg/vault/kv/v1_service.go
@@ -104,7 +104,7 @@ func (s *kvv1Backend) Read(ctx context.Context, path string) (SecretData, Secret
 	return secret.Data, nil, err
 }
 
-func (s *kvv1Backend) ReadVersion(ctx context.Context, path string, version uint) (SecretData, SecretMetadata, error) {
+func (s *kvv1Backend) ReadVersion(ctx context.Context, path string, version uint32) (SecretData, SecretMetadata, error) {
 	return s.Read(ctx, path)
 }
 

--- a/pkg/vault/kv/v2_service.go
+++ b/pkg/vault/kv/v2_service.go
@@ -86,7 +86,7 @@ func (s *kvv2Backend) Read(ctx context.Context, path string) (SecretData, Secret
 	return s.ReadVersion(ctx, path, 0)
 }
 
-func (s *kvv2Backend) ReadVersion(ctx context.Context, path string, version uint) (SecretData, SecretMetadata, error) {
+func (s *kvv2Backend) ReadVersion(ctx context.Context, path string, version uint32) (SecretData, SecretMetadata, error) {
 	// Clean path first
 	secretPath := vpath.SanitizePath(path)
 	if secretPath == "" {


### PR DESCRIPTION
# Context 

Fix a codeql finding for invalid integer parsing.