### PR TITLE
chore(tools): update to golangci-lint v1.37.0

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,17 +25,17 @@ jobs:
           git diff --exit-code go.mod
 
   # Run golangci-lint
-  #golangci-lint:
-  #  runs-on: ubuntu-latest
-  #  steps:
-  #    - uses: actions/checkout@v2
-  #    - name: lint
-  #      uses: golangci/golangci-lint-action@v2.4.0
-  #      with:
-  #        version: latest
+  golangci-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: lint
+        uses: golangci/golangci-lint-action@v2.4.0
+        with:
+          version: latest
 
   tests-on-windows:
-  #  needs: golangci-lint # run after golangci-lint action to not produce duplicated errors
+    needs: golangci-lint # run after golangci-lint action to not produce duplicated errors
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
@@ -57,7 +57,7 @@ jobs:
         run: gotestsum --format short-verbose ./pkg/...
 
   tests-on-macos:
-  #  needs: golangci-lint # run after golangci-lint action to not produce duplicated errors
+    needs: golangci-lint # run after golangci-lint action to not produce duplicated errors
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
@@ -79,7 +79,7 @@ jobs:
         run: gotestsum --format short-verbose ./pkg/...
 
   tests-on-unix:
-  #  needs: golangci-lint # run after golangci-lint action to not produce duplicated errors
+    needs: golangci-lint # run after golangci-lint action to not produce duplicated errors
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,6 +28,10 @@ jobs:
   golangci-lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
       - uses: actions/checkout@v2
       - name: lint
         uses: golangci/golangci-lint-action@v2.4.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,7 @@ linters:
     - exhaustivestruct
     - wrapcheck
     - ifshort
+    - cyclop
 
 output:
   format: colored-line-number

--- a/pkg/sdk/security/crypto/asymmetric.go
+++ b/pkg/sdk/security/crypto/asymmetric.go
@@ -48,7 +48,6 @@ func Keypair(keyType string) (interface{}, error) {
 
 // -----------------------------------------------------------------------------
 
-//nolint:gocyclo // To refactor
 func generateKeyPair(keyType string) (interface{}, interface{}, error) {
 	switch keyType {
 	case "rsa", "rsa:normal", "rsa:2048":

--- a/pkg/vault/logical/logical.mock.go
+++ b/pkg/vault/logical/logical.mock.go
@@ -5,9 +5,10 @@
 package logical
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	api "github.com/hashicorp/vault/api"
-	reflect "reflect"
 )
 
 // MockLogical is a mock of Logical interface

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/fatih/color v1.10.0
 	github.com/frapposelli/wwhrd v0.4.0
 	github.com/golang/mock v1.4.4
-	github.com/golangci/golangci-lint v1.36.0
+	github.com/golangci/golangci-lint v1.37.0
 	github.com/google/wire v0.5.0
 	github.com/izumin5210/gex v0.6.1
 	github.com/magefile/mage v1.11.0


### PR DESCRIPTION
# Context

`golangci-lint` released the `v1.37.0` version to support go 1.16.