### PR TITLE
fix(fuzz): patch rule with nil package.

### DIFF
--- a/pkg/bundle/patch/executor.go
+++ b/pkg/bundle/patch/executor.go
@@ -49,6 +49,9 @@ func executeRule(patchName string, r *bundlev1.PatchRule, p *bundlev1.Package, v
 	if r == nil {
 		return packageUnchanged, fmt.Errorf("cannot process nil rule")
 	}
+	if r.Package == nil {
+		return packageUnchanged, fmt.Errorf("cannot process rule with nil package")
+	}
 	if p == nil {
 		return packageUnchanged, fmt.Errorf("cannot process nil package")
 	}


### PR DESCRIPTION
# Context

Bug discovered by fuzz.

PBundlePatch rule with nil package declaration makes patch panic.