### PR TITLE
fix(template): use container reader.

### DIFF
--- a/cmd/harp/internal/cmd/template.go
+++ b/cmd/harp/internal/cmd/template.go
@@ -145,7 +145,7 @@ func runTemplate(cmd *cobra.Command, args []string) {
 		}
 
 		// Load container
-		b, errBundle := bundle.Load(containerReader)
+		b, errBundle := bundle.FromContainerReader(containerReader)
 		if errBundle != nil {
 			log.For(ctx).Fatal("unable to decode secret container", zap.Error(errBundle), zap.String("container-path", sr))
 		}


### PR DESCRIPTION
# Context

Template engine can load secret via `SecretLoaders`. You can load secret from vault or from a secret container. The secret container was using the old bundle loader before the separated container concept introduction.

