### PR TITLE
feat(crypto): move pasetov4 to security sdk.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ### Not released yet
 
+CHANGES:
+
+* crypto/paseto: move PASETO v4 primitives to `sdk/security/paseto/v4`. [#87](https://github.com/elastic/harp/pull/87)
+
+DIST:
+
+* nix/shell: Expose `shell.nix` to get a consistent development environment. [#87](https://github.com/elastic/harp/pull/87)
+
 ## 0.2.2
 
 ### 2021-11-24

--- a/README.md
+++ b/README.md
@@ -16,13 +16,14 @@
   - [License](#license)
 - [Homebrew install](#homebrew-install)
 - [Build instructions](#build-instructions)
-  - [First time](#first-time)
+  - [Clone repository](#clone-repository)
+  - [Manual dev environment](#manual-dev-environment)
     - [Check your go version](#check-your-go-version)
     - [Install mage](#install-mage)
       - [From source](#from-source)
-      - [From brew formula](#from-brew-formula)
-    - [Clone repository](#clone-repository)
-  - [Daily](#daily)
+    - [Daily](#daily)
+  - [With nix-shell](#with-nix-shell)
+  - [Bootstrap tools](#bootstrap-tools)
   - [Docker](#docker)
 - [Plugins](#plugins)
 - [Community](#community)
@@ -190,7 +191,14 @@ brew install elastic/harp/harp
 
 Download a [release](https://github.com/elastic/harp/releases) or build from source.
 
-## First time
+## Clone repository
+
+```sh
+$ git clone git@github.com:elastic/harp.git
+$ export HARP_REPOSITORY=$(pwd)/harp
+```
+
+## Manual dev environment
 
 ### Check your go version
 
@@ -219,27 +227,36 @@ cd mage
 go run bootstrap.go
 ```
 
-#### From brew formula
+### Daily
 
 ```sh
-brew install mage
-```
-
-### Clone repository
-
-```sh
-git clone git@github.com:elastic/harp.git
-# Go to tools submodule
-cd harp/tools
-# Pull tools sources, compile them and install executable in tools/bin
+export PATH=$HARP_REPOSITORY/tools/bin:$PATH
+# Build harp in bin folder
 mage
 ```
 
-## Daily
+## With nix-shell
+
+Install `nix` on your system, if not already installed.
 
 ```sh
-export PATH=$HARP_REPO/tools/bin:$PATH
-# Build harp in bin folder
+$ sudo install -d -m755 -o $(id -u) -g $(id -g) /nix
+$ curl -L https://nixos.org/nix/install | sh
+```
+
+> More information? - <https://nixos.wiki/wiki/Nix_Installation_Guide>
+
+```sh
+$ cd $HARP_REPOSITORY
+$ nix-shell
+```
+
+## Bootstrap tools
+
+```sh
+# Go to tools submodule
+cd $HARP_REPOSITORY/tools
+# Pull tools sources, compile them and install executable in tools/bin
 mage
 ```
 

--- a/pkg/sdk/security/crypto/paseto/v4/helpers.go
+++ b/pkg/sdk/security/crypto/paseto/v4/helpers.go
@@ -146,7 +146,6 @@ func Decrypt(key, input []byte, f, i string) ([]byte, error) {
 
 // PASETO v4 public signature primitive.
 // https://github.com/paseto-standard/paseto-spec/blob/master/docs/01-Protocol-Versions/Version4.md#sign
-//nolint:deadcode,unused // to be used in incoming release
 func Sign(m []byte, sk ed25519.PrivateKey, f, i string) ([]byte, error) {
 	// Compute protected content
 	m2, err := pae([]byte(v4PublicPrefix), m, []byte(f), []byte(i))
@@ -173,7 +172,6 @@ func Sign(m []byte, sk ed25519.PrivateKey, f, i string) ([]byte, error) {
 
 // PASETO v4 signature verification primitive.
 // https://github.com/paseto-standard/paseto-spec/blob/master/docs/01-Protocol-Versions/Version4.md#verify
-//nolint:deadcode,unused // to be used in incoming release
 func Verify(sm []byte, pk ed25519.PublicKey, f, i string) ([]byte, error) {
 	// Check token header
 	if !strings.HasPrefix(string(sm), v4PublicPrefix) {

--- a/pkg/sdk/security/crypto/paseto/v4/helpers.go
+++ b/pkg/sdk/security/crypto/paseto/v4/helpers.go
@@ -15,11 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package paseto
+package v4
 
 import (
 	"bytes"
 	"crypto/ed25519"
+	"crypto/rand"
 	"encoding/base64"
 	"encoding/binary"
 	"errors"
@@ -33,7 +34,8 @@ import (
 )
 
 const (
-	keyLength               = 32
+	// KeyLength is the requested encryption key size.
+	KeyLength               = 32
 	nonceLength             = 32
 	macLength               = 32
 	encryptionKDFLength     = 56
@@ -44,56 +46,31 @@ const (
 
 // PASETO v4 symmetric encryption primitive.
 // https://github.com/paseto-standard/paseto-spec/blob/master/docs/01-Protocol-Versions/Version4.md#encrypt
-func encrypt(key, n, m []byte, f, i string) ([]byte, error) {
-	// Check arguments
-	if len(key) != keyLength {
-		return nil, fmt.Errorf("paseto: invalid key length, it must be % bytes long", keyLength)
-	}
-	if len(n) != nonceLength {
-		return nil, fmt.Errorf("paseto: invalid nonce length, it must be %d bytes long", nonceLength)
+func Encrypt(key, m []byte, f, i string) ([]byte, error) {
+	// Create random seed
+	var n [32]byte
+	if _, err := rand.Read(n[:]); err != nil {
+		return nil, fmt.Errorf("paseto: unable to generate random seed: %w", err)
 	}
 
-	// Derive keys from seed and secret key
-	ek, n2, ak, err := kdf(key, n)
-	if err != nil {
-		return nil, fmt.Errorf("paseto: unable to derive keys from seed: %w", err)
-	}
-
-	// Prepare XChaCha20 stream cipher (nonce > 24bytes => XChacha)
-	ciph, err := chacha20.NewUnauthenticatedCipher(ek, n2)
-	if err != nil {
-		return nil, fmt.Errorf("paseto: unable to initialize XChaCha20 cipher: %w", err)
-	}
-
-	// Encrypt the payload
-	c := make([]byte, len(m))
-	ciph.XORKeyStream(c, m)
-
-	// Compute MAC
-	t, err := mac(ak, v4LocalPrefix, n, c, f, i)
-	if err != nil {
-		return nil, fmt.Errorf("paseto: unable to compute MAC: %w", err)
-	}
-
-	// Serialize final token
-	// h || base64url(n || c || t)
-	body := append([]byte{}, n...)
-	body = append(body, c...)
-	body = append(body, t...)
-
-	// Assemble final token
-	final := append([]byte(v4LocalPrefix), []byte(base64.RawURLEncoding.EncodeToString(body))...)
-	if f != "" {
-		final = append(final, append([]byte("."), []byte(base64.RawURLEncoding.EncodeToString([]byte(f)))...)...)
-	}
-
-	// No error
-	return final, nil
+	// Delegate to primitive
+	return encrypt(key, n[:], m, f, i)
 }
 
 // PASETO v4 symmetric decryption primitive
 // https://github.com/paseto-standard/paseto-spec/blob/master/docs/01-Protocol-Versions/Version4.md#decrypt
-func decrypt(key, input []byte, f, i string) ([]byte, error) {
+func Decrypt(key, input []byte, f, i string) ([]byte, error) {
+	// Check arguments
+	if key == nil {
+		return nil, errors.New("paseto: key is nil")
+	}
+	if len(key) != KeyLength {
+		return nil, fmt.Errorf("paseto: invalid key length, it must be %d bytes long", KeyLength)
+	}
+	if input == nil {
+		return nil, errors.New("paseto: input is nil")
+	}
+
 	// Check token header
 	if !strings.HasPrefix(string(input), v4LocalPrefix) {
 		return nil, errors.New("paseto: invalid token")
@@ -170,7 +147,7 @@ func decrypt(key, input []byte, f, i string) ([]byte, error) {
 // PASETO v4 public signature primitive.
 // https://github.com/paseto-standard/paseto-spec/blob/master/docs/01-Protocol-Versions/Version4.md#sign
 //nolint:deadcode,unused // to be used in incoming release
-func sign(m []byte, sk ed25519.PrivateKey, f, i string) ([]byte, error) {
+func Sign(m []byte, sk ed25519.PrivateKey, f, i string) ([]byte, error) {
 	// Compute protected content
 	m2, err := pae([]byte(v4PublicPrefix), m, []byte(f), []byte(i))
 	if err != nil {
@@ -197,7 +174,7 @@ func sign(m []byte, sk ed25519.PrivateKey, f, i string) ([]byte, error) {
 // PASETO v4 signature verification primitive.
 // https://github.com/paseto-standard/paseto-spec/blob/master/docs/01-Protocol-Versions/Version4.md#verify
 //nolint:deadcode,unused // to be used in incoming release
-func verify(sm []byte, pk ed25519.PublicKey, f, i string) ([]byte, error) {
+func Verify(sm []byte, pk ed25519.PublicKey, f, i string) ([]byte, error) {
 	// Check token header
 	if !strings.HasPrefix(string(sm), v4PublicPrefix) {
 		return nil, errors.New("paseto: invalid token")
@@ -256,6 +233,53 @@ func verify(sm []byte, pk ed25519.PublicKey, f, i string) ([]byte, error) {
 
 // -----------------------------------------------------------------------------
 
+func encrypt(key, n, m []byte, f, i string) ([]byte, error) {
+	// Check arguments
+	if len(key) != KeyLength {
+		return nil, fmt.Errorf("paseto: invalid key length, it must be %d bytes long", KeyLength)
+	}
+	if len(n) != nonceLength {
+		return nil, fmt.Errorf("paseto: invalid nonce length, it must be %d bytes long", nonceLength)
+	}
+
+	// Derive keys from seed and secret key
+	ek, n2, ak, err := kdf(key, n)
+	if err != nil {
+		return nil, fmt.Errorf("paseto: unable to derive keys from seed: %w", err)
+	}
+
+	// Prepare XChaCha20 stream cipher (nonce > 24bytes => XChacha)
+	ciph, err := chacha20.NewUnauthenticatedCipher(ek, n2)
+	if err != nil {
+		return nil, fmt.Errorf("paseto: unable to initialize XChaCha20 cipher: %w", err)
+	}
+
+	// Encrypt the payload
+	c := make([]byte, len(m))
+	ciph.XORKeyStream(c, m)
+
+	// Compute MAC
+	t, err := mac(ak, v4LocalPrefix, n, c, f, i)
+	if err != nil {
+		return nil, fmt.Errorf("paseto: unable to compute MAC: %w", err)
+	}
+
+	// Serialize final token
+	// h || base64url(n || c || t)
+	body := append([]byte{}, n...)
+	body = append(body, c...)
+	body = append(body, t...)
+
+	// Assemble final token
+	final := append([]byte(v4LocalPrefix), []byte(base64.RawURLEncoding.EncodeToString(body))...)
+	if f != "" {
+		final = append(final, append([]byte("."), []byte(base64.RawURLEncoding.EncodeToString([]byte(f)))...)...)
+	}
+
+	// No error
+	return final, nil
+}
+
 func kdf(key, n []byte) (ek, n2, ak []byte, err error) {
 	// Derive encryption key
 	encKDF, err := blake2b.New(encryptionKDFLength, key)
@@ -268,8 +292,8 @@ func kdf(key, n []byte) (ek, n2, ak []byte, err error) {
 	tmp := encKDF.Sum(nil)
 
 	// Split encryption key (Ek) and nonce (n2)
-	ek = tmp[:keyLength]
-	n2 = tmp[keyLength:]
+	ek = tmp[:KeyLength]
+	n2 = tmp[KeyLength:]
 
 	// Derive authentication key
 	authKDF, err := blake2b.New(authenticationKeyLength, key)

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,26 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+with pkgs;
+
+mkShell {
+  buildInputs = [
+    go_1_17
+    gotools
+    gopls
+    go-outline
+    gocode
+    gopkgs
+    gocode-gomod
+    godef
+    golint
+    delve
+    mage
+    protobuf
+    golangci-lint
+    upx
+  ];
+  shellHook =
+  ''
+    export PATH=$(pwd)/tools/bin:$PATH
+  '';
+}


### PR DESCRIPTION
# Context

PASETOv4 implementation embedded the transformer package. To make primitives more useable, I moved the PASETOv4 primitives to the security SDK.