### PR TITLE
feat(bundle): HCL bundle descriptor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 FEATURES:
 
+* bundle/from:
+  * read a `HCL` bundle descriptor to generate the binary bundle. [#114](https://github.com/elastic/harp/pull/114)
 * bundle/patch:
   * support `--stop-at-rule-index=<int>` and `--stop-at-rule-id=<string>` flags for `bundle patch` to stop patch
     evaluation before requested rule identifier or index. [#112](https://github.com/elastic/harp/pull/112)

--- a/cmd/harp/internal/cmd/from_hcl.go
+++ b/cmd/harp/internal/cmd/from_hcl.go
@@ -1,0 +1,62 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+
+	"github.com/elastic/harp/pkg/sdk/cmdutil"
+	"github.com/elastic/harp/pkg/sdk/log"
+	"github.com/elastic/harp/pkg/tasks/from"
+)
+
+// -----------------------------------------------------------------------------
+
+var fromHCLCmd = func() *cobra.Command {
+	var (
+		inputPath  string
+		outputPath string
+	)
+	cmd := &cobra.Command{
+		Use:   "hcl",
+		Short: "Convert a HCL based bundle DSL to a secret-container",
+		Run: func(cmd *cobra.Command, args []string) {
+			// Initialize logger and context
+			ctx, cancel := cmdutil.Context(cmd.Context(), "harp-from-hcl", conf.Debug.Enable, conf.Instrumentation.Logs.Level)
+			defer cancel()
+
+			// Prepare task
+			t := &from.HCLTask{
+				HCLReader:    cmdutil.FileReader(inputPath),
+				OutputWriter: cmdutil.FileWriter(outputPath),
+			}
+
+			// Run the task
+			if err := t.Run(ctx); err != nil {
+				log.For(ctx).Fatal("unable to execute task", zap.Error(err))
+			}
+		},
+	}
+
+	// Parameters
+	cmd.Flags().StringVar(&inputPath, "in", "-", "HCL configuration ('-' for stdin or filename)")
+	cmd.Flags().StringVar(&outputPath, "out", "-", "Container output ('-' for stdout or filename)")
+
+	return cmd
+}

--- a/docs/cmd/harp_from.md
+++ b/docs/cmd/harp_from.md
@@ -15,6 +15,7 @@ Secret container generation commands
 * [harp from consul](harp_from_consul.md)	 - Extract KV pairs from Hashicorp Consul KV Store
 * [harp from dump](harp_from_dump.md)	 - Import from bundle dump output as a secret container
 * [harp from etcd3](harp_from_etcd3.md)	 - Extract KV pairs from CoreOS Etcdv3 KV Store
+* [harp from hcl](harp_from_hcl.md)	 - Convert a HCL based bundle DSL to a secret-container
 * [harp from jsonmap](harp_from_jsonmap.md)	 - Convert a JSON map to a secret-container
 * [harp from object](harp_from_object.md)	 - Convert an object to a secret-container
 * [harp from oplog](harp_from_oplog.md)	 - Convert a JSON oplog to a secret-container

--- a/docs/cmd/harp_from_hcl.md
+++ b/docs/cmd/harp_from_hcl.md
@@ -1,0 +1,20 @@
+## harp from hcl
+
+Convert a HCL based bundle DSL to a secret-container
+
+```
+harp from hcl [flags]
+```
+
+### Options
+
+```
+  -h, --help         help for hcl
+      --in string    HCL configuration ('-' for stdin or filename) (default "-")
+      --out string   Container output ('-' for stdout or filename) (default "-")
+```
+
+### SEE ALSO
+
+* [harp from](harp_from.md)	 - Secret container generation commands
+

--- a/go.mod
+++ b/go.mod
@@ -105,7 +105,7 @@ require (
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/davecgh/go-spew v1.1.1
 	github.com/docker/cli v20.10.11+incompatible // indirect
 	github.com/docker/docker v20.10.7+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -150,6 +150,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
+	github.com/sebdah/goldie v1.0.0
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/cast v1.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -648,6 +648,7 @@ github.com/sebdah/goldie v1.0.0 h1:9GNhIat69MSlz/ndaBg48vl9dF5fI+NBB6kfOxgfkMc=
 github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
+github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sethvargo/go-diceware v0.2.1 h1:Dp1FZOYBPaJIzz8J2dUBqQnpd3DLsRR4ldBOFxiz4Gs=
 github.com/sethvargo/go-diceware v0.2.1/go.mod h1:lH5Q/oSPMivseNdhMERAC7Ti5oOPqsaVddU1BcN1CY0=

--- a/go.sum
+++ b/go.sum
@@ -644,6 +644,8 @@ github.com/sagikazarmark/crypt v0.3.0/go.mod h1:uD/D+6UF4SrIR1uGEv7bBNkNqLGqUr43
 github.com/sagikazarmark/crypt v0.4.0/go.mod h1:ALv2SRj7GxYV4HO9elxH9nS6M9gW+xDNxqmyJ6RfDFM=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/sebdah/goldie v1.0.0 h1:9GNhIat69MSlz/ndaBg48vl9dF5fI+NBB6kfOxgfkMc=
+github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=

--- a/pkg/bundle/hcl/config.go
+++ b/pkg/bundle/hcl/config.go
@@ -15,31 +15,19 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package cmd
+package hcl
 
-import (
-	"github.com/spf13/cobra"
-)
+// Config is the configuration structure for bundle DSL.
+type Config struct {
+	Annotations map[string]string `hcl:"annotations,optional"`
+	Labels      map[string]string `hcl:"labels,optional"`
+	Packages    []Package         `hcl:"package,block"`
+}
 
-// -----------------------------------------------------------------------------
-
-var fromCmd = func() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "from",
-		Short: "Secret container generation commands",
-	}
-
-	// Add subcommands
-	cmd.AddCommand(fromVaultCmd())
-	cmd.AddCommand(fromJSONCmd())
-	cmd.AddCommand(fromTemplateCmd())
-	cmd.AddCommand(fromDumpCmd())
-	cmd.AddCommand(fromOPLogCmd())
-	cmd.AddCommand(fromObjectCmd())
-	cmd.AddCommand(fromConsulCmd())
-	cmd.AddCommand(fromEtcd3Cmd())
-	cmd.AddCommand(fromZookeeperCmd())
-	cmd.AddCommand(fromHCLCmd())
-
-	return cmd
+type Package struct {
+	Path        string            `hcl:"path,label"`
+	Description string            `hcl:"description"`
+	Annotations map[string]string `hcl:"annotations,optional"`
+	Labels      map[string]string `hcl:"labels,optional"`
+	Secrets     map[string]string `hcl:"secrets"`
 }

--- a/pkg/bundle/hcl/parser.go
+++ b/pkg/bundle/hcl/parser.go
@@ -1,0 +1,48 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package hcl
+
+import (
+	"io"
+	"io/ioutil"
+
+	"github.com/hashicorp/hcl/v2/hclsimple"
+)
+
+// ParseFile parses the given file for a configuration. The syntax of the
+// file is determined based on the filename extension: "hcl" for HCL,
+// "json" for JSON, other is an error.
+func ParseFile(filename string) (*Config, error) {
+	var config Config
+	return &config, hclsimple.DecodeFile(filename, nil, &config)
+}
+
+// Parse parses the configuration from the given reader. The reader will be
+// read to completion (EOF) before returning so ensure that the reader
+// does not block forever.
+//
+// format is either "hcl" or "json"
+func Parse(r io.Reader, filename, format string) (*Config, error) {
+	src, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	var config Config
+	return &config, hclsimple.Decode("config.hcl", src, nil, &config)
+}

--- a/pkg/bundle/hcl/parser.go
+++ b/pkg/bundle/hcl/parser.go
@@ -18,8 +18,8 @@
 package hcl
 
 import (
+	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/hashicorp/hcl/v2/hclsimple"
 )
@@ -38,9 +38,9 @@ func ParseFile(filename string) (*Config, error) {
 //
 // format is either "hcl" or "json"
 func Parse(r io.Reader, filename, format string) (*Config, error) {
-	src, err := ioutil.ReadAll(r)
+	src, err := io.ReadAll(r)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to drain input reader: %w", err)
 	}
 
 	var config Config

--- a/pkg/bundle/hcl/testdata/basic.hcl
+++ b/pkg/bundle/hcl/testdata/basic.hcl
@@ -1,0 +1,7 @@
+package "app/credentials/database" {
+    description = ""
+
+    secrets = {
+        "USER" = "{{ strongPassword }}"
+    }
+}

--- a/pkg/bundle/hcl/testdata/basic.hcl.golden
+++ b/pkg/bundle/hcl/testdata/basic.hcl.golden
@@ -1,0 +1,15 @@
+(*hcl.Config)({
+ Annotations: (map[string]string) <nil>,
+ Labels: (map[string]string) <nil>,
+ Packages: ([]hcl.Package) (len=1 cap=1) {
+  (hcl.Package) {
+   Path: (string) (len=24) "app/credentials/database",
+   Description: (string) "",
+   Annotations: (map[string]string) <nil>,
+   Labels: (map[string]string) <nil>,
+   Secrets: (map[string]string) (len=1) {
+    (string) (len=4) "USER": (string) (len=20) "{{ strongPassword }}"
+   }
+  }
+ }
+})

--- a/pkg/bundle/hcl/testdata/complex.hcl
+++ b/pkg/bundle/hcl/testdata/complex.hcl
@@ -1,0 +1,21 @@
+# Complex sample
+
+# Bundle
+annotations = {
+    "secrets.elastic.co/leakSeverity" = "moderate"
+}
+
+# Packages
+package "platform/security/databases/postgresql" {
+    description = "Administrative access for database management."
+
+    annotations = {
+        "infosec.elastic.co/v1/SecretManagement#rotationPeriod" = "90"
+        "infosec.elastic.co/v1/SecretManagement#generationDate" = "{{ now | isodate }}"
+    }
+
+    secrets = {
+        "USER" = "admin-{{ randAlpha 8 }}"
+        "PASSWORD" = "{{ strongPassword | b64enc }}"
+    }
+}

--- a/pkg/bundle/hcl/testdata/complex.hcl.golden
+++ b/pkg/bundle/hcl/testdata/complex.hcl.golden
@@ -1,0 +1,21 @@
+(*hcl.Config)({
+ Annotations: (map[string]string) (len=1) {
+  (string) (len=31) "secrets.elastic.co/leakSeverity": (string) (len=8) "moderate"
+ },
+ Labels: (map[string]string) <nil>,
+ Packages: ([]hcl.Package) (len=1 cap=1) {
+  (hcl.Package) {
+   Path: (string) (len=38) "platform/security/databases/postgresql",
+   Description: (string) (len=46) "Administrative access for database management.",
+   Annotations: (map[string]string) (len=2) {
+    (string) (len=53) "infosec.elastic.co/v1/SecretManagement#generationDate": (string) (len=19) "{{ now | isodate }}",
+    (string) (len=53) "infosec.elastic.co/v1/SecretManagement#rotationPeriod": (string) (len=2) "90"
+   },
+   Labels: (map[string]string) <nil>,
+   Secrets: (map[string]string) (len=2) {
+    (string) (len=8) "PASSWORD": (string) (len=29) "{{ strongPassword | b64enc }}",
+    (string) (len=4) "USER": (string) (len=23) "admin-{{ randAlpha 8 }}"
+   }
+  }
+ }
+})

--- a/pkg/tasks/from/hcl.go
+++ b/pkg/tasks/from/hcl.go
@@ -52,7 +52,7 @@ func (t *HCLTask) Run(ctx context.Context) error {
 	// Parse input as HCL configuration object.
 	cfg, err := hcl.Parse(reader, "input", "hcl")
 	if err != nil {
-		return fmt.Errorf("unabel to parse input HCL: %w", err)
+		return fmt.Errorf("unable to parse input HCL: %w", err)
 	}
 
 	// Build the container from hcl dsl

--- a/pkg/tasks/from/hcl.go
+++ b/pkg/tasks/from/hcl.go
@@ -1,0 +1,77 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package from
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	bundlev1 "github.com/elastic/harp/api/gen/go/harp/bundle/v1"
+	"github.com/elastic/harp/pkg/bundle"
+	"github.com/elastic/harp/pkg/bundle/hcl"
+	"github.com/elastic/harp/pkg/tasks"
+)
+
+// JSONMapTask implements secret-container creation from JSON Map.
+type HCLTask struct {
+	HCLReader    tasks.ReaderProvider
+	OutputWriter tasks.WriterProvider
+}
+
+// Run the task.
+func (t *HCLTask) Run(ctx context.Context) error {
+	var (
+		reader io.Reader
+		writer io.Writer
+		b      *bundlev1.Bundle
+		err    error
+	)
+
+	// Create input reader
+	reader, err = t.HCLReader(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to read input reader: %w", err)
+	}
+
+	// Parse input as HCL configuration object.
+	cfg, err := hcl.Parse(reader, "input", "hcl")
+	if err != nil {
+		return fmt.Errorf("unabel to parse input HCL: %w", err)
+	}
+
+	// Build the container from hcl dsl
+	b, err = bundle.FromHCL(cfg)
+	if err != nil {
+		return fmt.Errorf("unable to create container from hcl: %w", err)
+	}
+
+	// Create output writer
+	writer, err = t.OutputWriter(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to open output writer: %w", err)
+	}
+
+	// Dump bundle
+	if err = bundle.ToContainerWriter(writer, b); err != nil {
+		return fmt.Errorf("unable to produce exported bundle: %w", err)
+	}
+
+	// No error
+	return nil
+}


### PR DESCRIPTION
# Context

Create Bundle from a HCLv2 descriptor.

```hcl
# Bundle
annotations = {
    "secrets.elastic.co/leakSeverity" = "moderate"
}

# Packages
package "platform/security/databases/postgresql" {
    description = "Administrative access for database management."

    annotations = {
        "infosec.elastic.co/v1/SecretManagement#rotationPeriod" = "90"
        "infosec.elastic.co/v1/SecretManagement#generationDate" = "{{ now | isodate }}"
    }

    secrets = {
        "USER" = "admin-{{ randAlpha 8 }}"
        "PASSWORD" = "{{ strongPassword | b64enc }}"
    }
}
```

```sh
$ harp template --in bundle.hcl | harp from hcl 
```