### PR TITLE
chore(ci): macos binaries code signing and notarization.

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -29,19 +29,87 @@ jobs:
           image: ghcr.io/elastic/harp/harp-artifacts-fips:v${{ github.event.inputs.release }}
           path: '/app/.'
       -
-        uses: sigstore/cosign-installer@v2.0.1
-      -
         name: Assemble a package
         run: |
           mkdir .dist
           cp ${{ steps.extract-std.outputs.destination }}/* .dist/
           cp ${{ steps.extract-fips.outputs.destination }}/* .dist/
       -
-        name: Create checksum
-        id: create-checksum
+        name: upload binary artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: binaries
+          path: .dist/
+          retention-days: 1
+
+  macos-release:
+    needs: package
+    runs-on: macos-latest
+    permissions:
+      packages: read
+      contents: write
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Download-Binaries
+        uses: actions/download-artifact@v2
+        with:
+          name: binaries
+          path: .dist/
+      -
+        name: Cleanup
+        shell: bash
+        run: |
+          cd .dist/
+          rm -f !(harp-darwin-*)
+      -
+        name: Import Code-Signing Certificates
+        uses: Apple-Actions/import-codesign-certs@v1
+        with:
+          p12-file-base64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}
+          p12-password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
+      -
+        name: Install gon via HomeBrew for code signing and app notarization
+        run: |
+          brew tap mitchellh/gon
+          brew install mitchellh/gon/gon
+      -
+        name: Sign the mac binaries with Gon
+        env:
+          AC_USERNAME: ${{ secrets.AC_USERNAME }}
+          AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
         run: |
           cd .dist
-          sha256sum * > checksum.txt
+          gon -log-level=debug -log-json ../build/artifact/gon.hcl
+      -
+        name: Upload binary artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: macos-binaries
+          path: .dist/
+          retention-days: 1
+
+  github-release:
+    needs: macos-release
+    runs-on: ubuntu-latest
+    permissions:
+      packages: read
+      contents: write
+    steps:
+      -
+        name: Download binaries
+        uses: actions/download-artifact@v2
+        with:
+          name: binaries
+          path: .dist/
+      -
+        name: Download MacOS signed binaries
+        uses: actions/download-artifact@v2
+        with:
+          name: macos-binaries
+          path: .dist/
       -
         name: Generate provenance for Release
         uses: philips-labs/slsa-provenance-action@v0.7.2
@@ -65,7 +133,7 @@ jobs:
             *.sbom.json)
                 gzip "$f"
                 ;;
-            checksum.txt|provenance.json)
+            provenance.json)
                 cosign sign-blob --key <(echo -n "${COSIGN_KEY}") "$f" > "$f.sig"
                 ;;
             harp-*)

--- a/build/artifact/gon.hcl
+++ b/build/artifact/gon.hcl
@@ -1,0 +1,16 @@
+source = [
+    "harp-darwin-amd64",
+    "harp-darwin-amd64-fips",
+    "harp-darwin-arm64",
+    "harp-darwin-arm64-fips"
+]
+
+bundle_id = "co.elastic.harp"
+
+apple_id {
+  password = "@env:AC_PASSWORD"
+}
+
+sign {
+  application_identity = "9470D0A7B70090A8EF31C3B33AB3868B38B27A3D"
+}


### PR DESCRIPTION
# Context

Add MacOS binaries code signing and notarization to release process.