### PR TITLE
Fix yaml serialization from pb

### DIFF
--- a/api/jsonschema/harp.bundle.v1/RuleSet.json
+++ b/api/jsonschema/harp.bundle.v1/RuleSet.json
@@ -80,7 +80,7 @@
           "description": "RuleSet name."
         },
         "owner": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "RuleSet owner."
         },
         "description": {
@@ -88,7 +88,7 @@
           "description": "Short description for ruleset."
         }
       },
-      "required": ["name", "owner", "description"],
+      "required": ["name", "description"],
       "additionalProperties": false,
       "type": "object",
       "title": "Rule Set Meta",

--- a/pkg/sdk/convert/yaml.go
+++ b/pkg/sdk/convert/yaml.go
@@ -25,6 +25,8 @@ import (
 	"io"
 	"reflect"
 
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 	"sigs.k8s.io/yaml"
 
 	"github.com/elastic/harp/pkg/sdk/types"
@@ -45,6 +47,35 @@ func YAMLtoJSON(r io.Reader) (io.Reader, error) {
 
 	// No error
 	return jsonReader, nil
+}
+
+// PBtoYAML converts a protobuf object to a YAML representation
+func PBtoYAML(msg proto.Message) ([]byte, error) {
+	// Check arguments
+	if types.IsNil(msg) {
+		return nil, fmt.Errorf("msg is nil")
+	}
+
+	// Encode protbuf message as JSON
+	pb, err := protojson.Marshal(msg)
+	if err != nil {
+		return nil, fmt.Errorf("unable to encode protbuf message to JSON: %w", err)
+	}
+
+	// Decode input as JSON
+	var jsonObj interface{}
+	if errDecode := yaml.Unmarshal(pb, &jsonObj); errDecode != nil {
+		return nil, fmt.Errorf("unable to decode JSON input: %w", errDecode)
+	}
+
+	// Marshal as YAML
+	out, errEncode := yaml.Marshal(jsonObj)
+	if errEncode != nil {
+		return nil, fmt.Errorf("unable to produce YAML output: %w", errEncode)
+	}
+
+	// No error
+	return out, nil
 }
 
 // -----------------------------------------------------------------------------

--- a/pkg/sdk/convert/yaml_test.go
+++ b/pkg/sdk/convert/yaml_test.go
@@ -20,7 +20,39 @@ package convert
 import (
 	"reflect"
 	"testing"
+
+	bundlev1 "github.com/elastic/harp/api/gen/go/harp/bundle/v1"
+	"github.com/google/go-cmp/cmp"
 )
+
+func Test_PBtoYAML(t *testing.T) {
+	spec := &bundlev1.Patch{
+		ApiVersion: "harp.elastic.co/v1",
+		Kind:       "BundlePatch",
+		Meta: &bundlev1.PatchMeta{
+			Name: "test-patch",
+		},
+		Spec: &bundlev1.PatchSpec{
+			Rules: []*bundlev1.PatchRule{
+				{
+					Package:  &bundlev1.PatchPackage{},
+					Selector: &bundlev1.PatchSelector{},
+				},
+			},
+		},
+	}
+
+	expectedOutput := []byte("apiVersion: harp.elastic.co/v1\nkind: BundlePatch\nmeta:\n  name: test-patch\nspec:\n  rules:\n  - package: {}\n    selector: {}\n")
+
+	out, err := PBtoYAML(spec)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if report := cmp.Diff(string(out), string(expectedOutput)); report != "" {
+		t.Errorf("unexpected conversion output:\n%v", report)
+	}
+}
 
 func Test_convertMapStringInterface(t *testing.T) {
 	type args struct {

--- a/pkg/tasks/bundle/diff.go
+++ b/pkg/tasks/bundle/diff.go
@@ -23,10 +23,9 @@ import (
 	"errors"
 	"fmt"
 
-	"sigs.k8s.io/yaml"
-
 	"github.com/elastic/harp/pkg/bundle"
 	"github.com/elastic/harp/pkg/bundle/compare"
+	"github.com/elastic/harp/pkg/sdk/convert"
 	"github.com/elastic/harp/pkg/sdk/types"
 	"github.com/elastic/harp/pkg/tasks"
 )
@@ -100,8 +99,8 @@ func (t *DiffTask) Run(ctx context.Context) error {
 			return fmt.Errorf("unable to convert oplog as a bundle patch: %w", err)
 		}
 
-		// Marshal YAML Patch
-		out, err := yaml.Marshal(patch)
+		// Marshal as YAML
+		out, err := convert.PBtoYAML(patch)
 		if err != nil {
 			return fmt.Errorf("unable to marshal patch as YAML: %w", err)
 		}

--- a/pkg/tasks/to/ruleset.go
+++ b/pkg/tasks/to/ruleset.go
@@ -21,10 +21,9 @@ import (
 	"context"
 	"fmt"
 
-	"sigs.k8s.io/yaml"
-
 	"github.com/elastic/harp/pkg/bundle"
 	"github.com/elastic/harp/pkg/bundle/ruleset"
+	"github.com/elastic/harp/pkg/sdk/convert"
 	"github.com/elastic/harp/pkg/tasks"
 )
 
@@ -55,9 +54,9 @@ func (t *RuleSetTask) Run(ctx context.Context) error {
 	}
 
 	// Marshal as YAML
-	ruleSetSpec, err := yaml.Marshal(rs)
+	out, err := convert.PBtoYAML(rs)
 	if err != nil {
-		return fmt.Errorf("unable to generate YAML descriptor: %w", err)
+		return fmt.Errorf("unable to marshal as YAML: %w", err)
 	}
 
 	// Create output writer
@@ -67,7 +66,7 @@ func (t *RuleSetTask) Run(ctx context.Context) error {
 	}
 
 	// Write output
-	fmt.Fprintln(writer, string(ruleSetSpec))
+	fmt.Fprintln(writer, string(out))
 
 	// No error
 	return nil


### PR DESCRIPTION
# Context

* Make `owner` not mandatory in `RuleSet`JSON Schema
* Add a Protobuf to YAML conversion helper who uses protojson as an intermediary encoder to get the right protobuf object annotations
* Apply fix to `RuleSet`and `Patch` tasks which were producing an `api_version` property instead of the expected `apiVersion` format

```
$ harp from object --in ~/demo/219/input.json --out - | harp to ruleset --in -
apiVersion: harp.elastic.co/v1
kind: RuleSet
meta:
  description: Generated from bundle content
  name: qBiWpFkYKhkuBUXyIxxA1fSWCDXV8jHBJkgArt7D2dwqZ4mn_k7s2JbomfjzB_tNEI9CJXJ1n5cflhb96ao3lA
spec:
  rules:
  - constraints:
    - p.has_secret("bar")
    name: LINT-qBiWpF-1
    path: secrets/foo/test
```

# Reference(s)

fix https://github.com/elastic/harp/issues/219