### PR TITLE
pinning github actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -96,7 +96,7 @@ jobs:
         uses: actions/checkout@v4
       -
         name: Lint code
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@4696ba8babb6127d732c3c6dde519db15edab9ea  # v6.5.1
         with:
           version: latest
           args: --timeout=10m
@@ -127,7 +127,7 @@ jobs:
         run: go mod download
       -
         name: Setup gotestsum
-        uses: autero1/action-gotestsum@v2.0.0
+        uses: autero1/action-gotestsum@7263b9d73912eec65f46337689e59fac865c425f # v2.0.0
         with:
           gotestsum_version: 1.12.0
       -
@@ -160,7 +160,7 @@ jobs:
         run: go mod download
       -
         name: Setup gotestsum
-        uses: autero1/action-gotestsum@v2.0.0
+        uses: autero1/action-gotestsum@7263b9d73912eec65f46337689e59fac865c425f # v2.0.0
         with:
           gotestsum_version: 1.12.0
       -
@@ -193,7 +193,7 @@ jobs:
         run: go mod download
       -
         name: Setup gotestsum
-        uses: autero1/action-gotestsum@v2.0.0
+        uses: autero1/action-gotestsum@7263b9d73912eec65f46337689e59fac865c425f # v2.0.0
         with:
           gotestsum_version: 1.12.0
       -

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -39,7 +39,7 @@ jobs:
             ${{ runner.os }}-go-
       -
         name: Download cyclonedx-gomod
-        uses: Zenithar/gh-gomod-generate-sbom@v1.0.1
+        uses: Zenithar/gh-gomod-generate-sbom@cd97098f01c993f4aa90ccb8aaf6d795d6194898  # v1.0.1
         with:
           version: v1.2.0
         env:
@@ -49,7 +49,7 @@ jobs:
         uses: sigstore/cosign-installer@v3.8.1
       -
         name: Import Code-Signing Certificates
-        uses: Apple-Actions/import-codesign-certs@v3
+        uses: Apple-Actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d  # v3
         with:
           p12-file-base64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}
           p12-password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
@@ -61,7 +61,7 @@ jobs:
           brew install coreutils
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200  # v6.0.0
         with:
           version: latest
           args: release --rm-dist --skip-publish
@@ -183,7 +183,7 @@ jobs:
           done
       -
         name: Upload to release
-        uses: AButler/upload-release-assets@v2.0
+        uses: AButler/upload-release-assets@ec6d3263266dc57eb6645b5f75e827987f7c217d  # v2.0
         with:
           files: '.dist/*'
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,7 +30,7 @@ jobs:
         run: go list -json -m all > go.list
       -
         name: Nancy
-        uses: sonatype-nexus-community/nancy-github-action@v1.0.3
+        uses: sonatype-nexus-community/nancy-github-action@aae196481b961d446f4bff9012e4e3b63d7921a4  # v1.0.2
 
   trivy:
     name: Trivy scanner
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v4
       -
         name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9724c8a5e33bc2d97a5  # v0.30.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true
@@ -101,7 +101,7 @@ jobs:
       -
         uses: actions/checkout@v4
       -
-        uses: returntocorp/semgrep-action@v1
+        uses: returntocorp/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d # v1
         with:
           generateSarif: "1"
           config: >-


### PR DESCRIPTION
Pinning action to a full length commit SHA [see](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)