### PR TITLE
refactor: remove unnecessary go build tags

### DIFF
--- a/pkg/bundle/fs/api.go
+++ b/pkg/bundle/fs/api.go
@@ -15,9 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build go1.16
-// +build go1.16
-
 package fs
 
 import "io/fs"

--- a/pkg/bundle/fs/directory.go
+++ b/pkg/bundle/fs/directory.go
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build go1.16
-
 package fs
 
 import (

--- a/pkg/bundle/fs/direntry.go
+++ b/pkg/bundle/fs/direntry.go
@@ -15,9 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build go1.16
-// +build go1.16
-
 package fs
 
 import "io/fs"

--- a/pkg/bundle/fs/file.go
+++ b/pkg/bundle/fs/file.go
@@ -15,9 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build go1.16
-// +build go1.16
-
 package fs
 
 import (

--- a/pkg/bundle/fs/file_info.go
+++ b/pkg/bundle/fs/file_info.go
@@ -15,9 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build go1.16
-// +build go1.16
-
 package fs
 
 import (

--- a/pkg/bundle/fs/root.go
+++ b/pkg/bundle/fs/root.go
@@ -15,9 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build go1.16
-// +build go1.16
-
 package fs
 
 import (

--- a/pkg/bundle/fs/root_test.go
+++ b/pkg/bundle/fs/root_test.go
@@ -15,9 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build go1.16
-// +build go1.16
-
 package fs
 
 import (

--- a/test/fuzz/bundle/loader/fuzz_test.go
+++ b/test/fuzz/bundle/loader/fuzz_test.go
@@ -15,9 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build go1.18
-// +build go1.18
-
 package loader_test
 
 import (

--- a/test/fuzz/template/fuzz_test.go
+++ b/test/fuzz/template/fuzz_test.go
@@ -15,9 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build go1.18
-// +build go1.18
-
 package loader_test
 
 import (


### PR DESCRIPTION
go.mod requires go 1.23, remove old go version build tag