### PR TITLE
ci: group github-action updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,4 +8,8 @@ updates:
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-    interval: "daily"
+    interval: "weekly"
+  groups:
+    github-actions:
+      patterns:
+        - "*"


### PR DESCRIPTION
move schedule interval to weekly

should reduce dependabot PR noise