### PR TITLE
fix: stabilize linux CI — diceware flake + semgrep false-positive suppressions

### DIFF
--- a/pkg/bundle/builders.go
+++ b/pkg/bundle/builders.go
@@ -56,6 +56,7 @@ func FromDump(r io.Reader) (*bundlev1.Bundle, error) {
 	for _, p := range b.Packages {
 		for _, s := range p.Secrets.Data {
 			// Decode json encoded value
+			// nosemgrep: go.lang.security.deserialization.unsafe-deserialization-interface.go-unsafe-deserialization-interface -- secret values are user-defined arbitrary JSON by design
 			var data interface{}
 			if errJSON := json.Unmarshal(s.Value, &data); errJSON != nil {
 				return nil, fmt.Errorf("unable to decode '%s' - '%s' secret value as json: %w", p.Name, s.Key, errJSON)

--- a/pkg/sdk/convert/yaml.go
+++ b/pkg/sdk/convert/yaml.go
@@ -63,6 +63,7 @@ func PBtoYAML(msg proto.Message) ([]byte, error) {
 	}
 
 	// Decode input as JSON
+	// nosemgrep: go.lang.security.deserialization.unsafe-deserialization-interface.go-unsafe-deserialization-interface -- generic protobuf->JSON->YAML converter; structure is caller-defined
 	var jsonObj interface{}
 	if errDecode := yaml.Unmarshal(pb, &jsonObj); errDecode != nil {
 		return nil, fmt.Errorf("unable to decode JSON input: %w", errDecode)
@@ -98,6 +99,7 @@ func loadFromYAML(r io.Reader) (io.Reader, error) {
 	}
 
 	// Decode as YAML any object
+	// nosemgrep: go.lang.security.deserialization.unsafe-deserialization-interface.go-unsafe-deserialization-interface -- generic YAML->JSON converter must accept arbitrary structure
 	var specBody interface{}
 	if errYaml := yaml.Unmarshal(in, &specBody); errYaml != nil {
 		return nil, fmt.Errorf("unable to decode spec as YAML: %w", err)

--- a/pkg/sdk/security/crypto/encoder.go
+++ b/pkg/sdk/security/crypto/encoder.go
@@ -322,6 +322,7 @@ func DecryptJWE(key, token string) (interface{}, error) {
 	}
 
 	// Decode payload
+	// nosemgrep: go.lang.security.deserialization.unsafe-deserialization-interface.go-unsafe-deserialization-interface -- DecryptJWE returns decoded payload as interface{} to caller; payload shape is caller-defined
 	var data interface{}
 	if err := json.Unmarshal(payloadBytes, &data); err != nil {
 		return "", fmt.Errorf("unable to decode payload: %w", err)

--- a/pkg/sdk/security/diceware/generator.go
+++ b/pkg/sdk/security/diceware/generator.go
@@ -55,6 +55,15 @@ func Diceware(count int) (string, error) {
 		return "", fmt.Errorf("unable to generate daceware passphrase: %w", err)
 	}
 
+	// The EFF word list contains a handful of hyphenated entries
+	// (e.g. "t-shirt"). Strip internal hyphens so the "-" separator
+	// remains an unambiguous word boundary for consumers.
+	for i, w := range list {
+		if strings.ContainsRune(w, '-') {
+			list[i] = strings.ReplaceAll(w, "-", "")
+		}
+	}
+
 	// Assemble result
 	return strings.Join(list, "-"), nil
 }

--- a/pkg/sdk/security/diceware/generator_test.go
+++ b/pkg/sdk/security/diceware/generator_test.go
@@ -131,6 +131,32 @@ func TestPredefined(t *testing.T) {
 	}
 }
 
+// TestDiceware_TokenCountStable exercises the hyphen-stripping branch added to
+// guard against EFF word-list entries that contain an internal hyphen (e.g.
+// "t-shirt"). The upstream library picks such words at a per-word probability
+// of roughly 4/7776, so a single call rarely reproduces the flake; a
+// high-iteration loop at MaxWordCount makes the assertion reliable while
+// remaining fast. Regression for the "splitting on '-' yields more tokens than
+// requested" flake.
+func TestDiceware_TokenCountStable(t *testing.T) {
+	const iterations = 500
+	for i := range iterations {
+		got, err := Diceware(MaxWordCount)
+		if err != nil {
+			t.Fatalf("Diceware(%d) unexpected error on iteration %d: %v", MaxWordCount, i, err)
+		}
+		gotWordCount := len(strings.Split(got, "-"))
+		if gotWordCount != MaxWordCount {
+			t.Fatalf("Diceware(%d) iteration %d: token count = %d, want %d (output=%q)",
+				MaxWordCount, i, gotWordCount, MaxWordCount, got)
+		}
+		if strings.Contains(got, "--") {
+			t.Fatalf("Diceware(%d) iteration %d: output has empty token (output=%q)",
+				MaxWordCount, i, got)
+		}
+	}
+}
+
 // -----------------------------------------------------------------------------
 
 func TestDiceware_Fuzz(t *testing.T) {


### PR DESCRIPTION
## Notes for Reviewer

- [x] Fixed flaky `TestPredefined` / `TestDiceware` in `pkg/sdk/security/diceware`: the EFF large word list contains 4 hyphenated entries (`drop-down`, `felt-tip`, `t-shirt`, `yo-yo`); joining output with `-` and splitting with `-` inflated the count.
  Generator now strips internal hyphens from each word before joining so `-` remains
an unambiguous token boundary.
  Passphrase word count is preserved; entropy impact is negligible (4/7776 per word).
- [x] Added `TestDiceware_TokenCountStable` — 500 iterations at `MaxWordCount` to deterministically lock the invariant (pre-fix failure probability at 500 iters is
effectively 100%; runtime ~30ms).
- [x] Suppressed 4 `go-unsafe-deserialization-interface` findings that are false positives at generic-format-converter sites (`pkg/bundle/builders.go`, `pkg/sdk/convert/yaml.go` x2, `pkg/sdk/security/crypto/encoder.go`).
  Each inline `// nosemgrep:` comment includes the full rule id and a one-line justification.