### PR TITLE
fix(patch): apply `remove: true` to all matching packages

### DIFF
--- a/pkg/bundle/patch/package.go
+++ b/pkg/bundle/patch/package.go
@@ -163,7 +163,8 @@ func Apply(spec *bundlev1.Patch, b *bundlev1.Bundle, values map[string]interface
 		}
 
 		// Process all packages
-		for i, p := range bCopy.Packages {
+		keptPackages := make([]*bundlev1.Package, 0, len(bCopy.Packages))
+		for _, p := range bCopy.Packages {
 			action, err := executeRule(r, p, values)
 			if err != nil {
 				return nil, fmt.Errorf("unable to execute rule index %d: %w", ri, err)
@@ -171,19 +172,21 @@ func Apply(spec *bundlev1.Patch, b *bundlev1.Bundle, values map[string]interface
 
 			switch action {
 			case packagedRemoved:
-				bCopy.Packages = append(bCopy.Packages[:i], bCopy.Packages[i+1:]...)
+				continue
 			case packageUpdated:
 				if WithAnnotations(spec) {
 					// Add annotations to mark package as patched.
 					bundle.Annotate(p, "patched", "true")
 					bundle.Annotate(p, spec.Meta.Name, "true")
 				}
-				bCopy.Packages[i] = p
 			case packageUnchanged:
 				// No changes
 			default:
 			}
+
+			keptPackages = append(keptPackages, p)
 		}
+		bCopy.Packages = keptPackages
 	}
 
 	// Sort packages

--- a/pkg/bundle/patch/package_test.go
+++ b/pkg/bundle/patch/package_test.go
@@ -395,6 +395,46 @@ func TestApply(t *testing.T) {
 			},
 		},
 		{
+			name: "remove multiple adjacent packages with regex",
+			args: args{
+				spec: mustLoadPatch("../../../test/fixtures/patch/valid/remove-packages-by-regex.yaml"),
+				b: &bundlev1.Bundle{
+					Packages: []*bundlev1.Package{
+						{Name: "app/aaa"},
+						{Name: "app/bbb"},
+						{Name: "app/ccc"},
+						{Name: "app/zzz"},
+					},
+				},
+				values: map[string]interface{}{},
+			},
+			wantErr: false,
+			want: &bundlev1.Bundle{
+				Packages: []*bundlev1.Package{
+					{Name: "app/ccc"},
+					{Name: "app/zzz"},
+				},
+			},
+		},
+		{
+			name: "remove all packages",
+			args: args{
+				spec: mustLoadPatch("../../../test/fixtures/patch/valid/remove-all-packages.yaml"),
+				b: &bundlev1.Bundle{
+					Packages: []*bundlev1.Package{
+						{Name: "pkg-a"},
+						{Name: "pkg-b"},
+						{Name: "pkg-c"},
+					},
+				},
+				values: map[string]interface{}{},
+			},
+			wantErr: false,
+			want: &bundlev1.Bundle{
+				Packages: []*bundlev1.Package{},
+			},
+		},
+		{
 			name: "remove secrets with secret matcher",
 			args: args{
 				spec: mustLoadPatch("../../../test/fixtures/patch/valid/remove-secrets.yaml"),

--- a/test/fixtures/patch/valid/remove-all-packages.yaml
+++ b/test/fixtures/patch/valid/remove-all-packages.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=../../../../api/jsonschema/harp.bundle.v1/Patch.json
+apiVersion: harp.elastic.co/v1
+kind: BundlePatch
+meta:
+  name: "all-packages-remover"
+  owner: security@elastic.co
+  description: "Remove all packages in the bundle"
+spec:
+  rules:
+    - selector:
+        matchPath:
+          regex: ".*"
+      package:
+        remove: true

--- a/test/fixtures/patch/valid/remove-packages-by-regex.yaml
+++ b/test/fixtures/patch/valid/remove-packages-by-regex.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=../../../../api/jsonschema/harp.bundle.v1/Patch.json
+apiVersion: harp.elastic.co/v1
+kind: BundlePatch
+meta:
+  name: "regex-package-remover"
+  owner: security@elastic.co
+  description: "Remove multiple packages matched by a regex selector"
+spec:
+  rules:
+    - selector:
+        matchPath:
+          regex: "^app/(aaa|bbb)$"
+      package:
+        remove: true


### PR DESCRIPTION
**Issue**:

See #464

**Cause**:

The loop removes entries from `bCopy.Packages` while iterating over that same slice. Because the slice is compacted in place during `range`, adjacent matches can be skipped, and all-matching cases can also crash.

**Fix**:

Replace the in-place mutation with an accumulate-and-replace filter: collect packages to keep in a fresh `keptPackages` slice, then assign it back after each rule.

**Verification**:

```shell
$ cat > input.json <<'EOF'
{
  "app/aaa": {"k": "v1"},
  "app/bbb": {"k": "v2"},
  "app/ccc": {"k": "v3"},
  "app/zzz": {"k": "v4"}
}
EOF
$ harp from jsonmap --in input.json > in.bundle
$ cat > patch.yaml <<'EOF'
apiVersion: harp.elastic.co/v1
kind: BundlePatch
meta:
  name: remove-adjacent
spec:
  rules:
    - selector:
        matchPath:
          regex: "^app/(aaa|bbb)$"
      package:
        remove: true
EOF
$ bin/harp-linux-amd64 version
cmd/harp/v0.2.8-142-g9d27742 [fix/patch-remove-multiple-packages:9d27742] (Go: go1.25.8 linux/amd64, Flags: defaults, Date: 2026-08-23T23:41:03Z)
$ bin/harp-linux-amd64 bundle patch --in in.bundle --spec patch.yaml > out.bundle
$ harp bundle dump --in out.bundle --path-only
app/ccc
app/zzz
# ↑ Both "^app/(aaa|bbb)$" are properly removed.
```

Closes #464