### PR TITLE
fix(patch): keep package secrets when no kv operation applies

### DIFF
--- a/pkg/bundle/patch/executor.go
+++ b/pkg/bundle/patch/executor.go
@@ -356,7 +356,7 @@ func applySecretKVPatch(kv []*bundlev1.KV, op *bundlev1.PatchOperation, values m
 		return nil, fmt.Errorf("cannot process nil operation")
 	}
 
-	var out []*bundlev1.KV
+	out := kv
 
 	// Remove all keys
 	if len(op.RemoveKeys) > 0 {

--- a/pkg/bundle/patch/package_test.go
+++ b/pkg/bundle/patch/package_test.go
@@ -678,6 +678,99 @@ func TestApply(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "keep secrets with an empty kv operation",
+			args: args{
+				spec: mustLoadPatch("../../../test/fixtures/patch/valid/empty-kv-operation.yaml"),
+				b: &bundlev1.Bundle{
+					Packages: []*bundlev1.Package{
+						{
+							Name: "app/target",
+							Secrets: &bundlev1.SecretChain{
+								Data: []*bundlev1.KV{
+									{Key: "k", Value: []byte("v")},
+								},
+							},
+						},
+					},
+				},
+				values: map[string]interface{}{},
+			},
+			wantErr: false,
+			want: &bundlev1.Bundle{
+				Packages: []*bundlev1.Package{
+					{
+						Name: "app/target",
+						Annotations: map[string]string{
+							"patched":  "true",
+							"empty-kv": "true",
+						},
+						Secrets: &bundlev1.SecretChain{
+							Data: []*bundlev1.KV{
+								{Key: "k", Value: []byte("v")},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "keep secrets when removeKeys matches no key",
+			args: args{
+				spec: mustLoadPatch("../../../test/fixtures/patch/valid/remove-keys-by-prefix.yaml"),
+				b: &bundlev1.Bundle{
+					Packages: []*bundlev1.Package{
+						{
+							Name: "app/aaa",
+							Secrets: &bundlev1.SecretChain{
+								Data: []*bundlev1.KV{
+									{Key: "real_key", Value: []byte("should-survive")},
+								},
+							},
+						},
+						{
+							Name: "app/bbb",
+							Secrets: &bundlev1.SecretChain{
+								Data: []*bundlev1.KV{
+									{Key: "tmp_key", Value: []byte("v1")},
+									{Key: "keep", Value: []byte("keep-this")},
+								},
+							},
+						},
+					},
+				},
+				values: map[string]interface{}{},
+			},
+			wantErr: false,
+			want: &bundlev1.Bundle{
+				Packages: []*bundlev1.Package{
+					{
+						Name: "app/aaa",
+						Annotations: map[string]string{
+							"patched":              "true",
+							"prefixed-key-remover": "true",
+						},
+						Secrets: &bundlev1.SecretChain{
+							Data: []*bundlev1.KV{
+								{Key: "real_key", Value: []byte("should-survive")},
+							},
+						},
+					},
+					{
+						Name: "app/bbb",
+						Annotations: map[string]string{
+							"patched":              "true",
+							"prefixed-key-remover": "true",
+						},
+						Secrets: &bundlev1.SecretChain{
+							Data: []*bundlev1.KV{
+								{Key: "keep", Value: []byte("keep-this")},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/test/fixtures/patch/valid/empty-kv-operation.yaml
+++ b/test/fixtures/patch/valid/empty-kv-operation.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=../../../../api/jsonschema/harp.bundle.v1/Patch.json
+apiVersion: harp.elastic.co/v1
+kind: BundlePatch
+meta:
+  name: "empty-kv"
+  owner: security@elastic.co
+  description: "Patch secrets with an empty kv operation"
+spec:
+  rules:
+    - selector:
+        matchPath:
+          regex: ".*"
+      package:
+        data:
+          kv: {}

--- a/test/fixtures/patch/valid/remove-keys-by-prefix.yaml
+++ b/test/fixtures/patch/valid/remove-keys-by-prefix.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=../../../../api/jsonschema/harp.bundle.v1/Patch.json
+apiVersion: harp.elastic.co/v1
+kind: BundlePatch
+meta:
+  name: "prefixed-key-remover"
+  owner: security@elastic.co
+  description: "Remove secret keys matching a name prefix"
+spec:
+  rules:
+    - selector:
+        matchPath:
+          regex: "^app/"
+      package:
+        data:
+          kv:
+            removeKeys:
+              - "^tmp_"


### PR DESCRIPTION
**Issue**:

See #466

**Cause**:

`applySecretKVPatch` starts with a nil result and only assigns it inside one of the four operation branches. A `kv` block that triggers no operation — an empty block, or `removeKeys` whose pattern matches no key in the package — leaves the result nil, and the caller assigns that nil over the package's existing secrets.

**Fix**:

Initialise the result with the incoming secret list, so a `kv` block that triggers no operation returns the package secrets unchanged.

**Verification**:

```shell
$ echo '{"app/target":{"k":"v","k2":"v2"}}' | harp from jsonmap > in.bundle
$ cat > empty-kv.yaml <<'EOF'
apiVersion: harp.elastic.co/v1
kind: BundlePatch
meta:
  name: empty-kv
spec:
  rules:
    - selector:
        matchPath:
          regex: "^app/"
      package:
        data:
          kv: {}
EOF
$ bin/harp-linux-amd64 version
cmd/harp/v0.2.8-142-g3e8f8c6 [fix/patch-kv-preserve-secrets:3e8f8c6] (Go: go1.25.8 linux/amd64, Flags: defaults, Date: 2026-08-23T23:32:42Z)
$ bin/harp-linux-amd64 bundle patch --in in.bundle --spec empty-kv.yaml > out.bundle
$ harp bundle dump --in out.bundle --data-only
{"app/target":{"k":"v","k2":"v2"}}
# ↑ The built `bin/harp-linux-amd64` doesn't wipe any package secrets even though no operation is specified.
```

Closes #466